### PR TITLE
Blueprint Generation Overhaul

### DIFF
--- a/Algorithms/GridShaper.cs
+++ b/Algorithms/GridShaper.cs
@@ -93,6 +93,7 @@ public class GridShaper
         // Initialize ILGPU Context
         using var context = Context.CreateDefault();
         using var accelerator = context.GetPreferredDevice(preferCPU: false).CreateAccelerator(context);
+        System.Diagnostics.Debug.WriteLine($"\n[ILGPU VERIFICATION] Executing on: {accelerator.Name} (Type: {accelerator.AcceleratorType})\n");
 
         // Prepare Triangle Data
         int triangleCount = this.Mesh.TriangleCount;
@@ -673,10 +674,9 @@ public class GridShaper
         }
     }
 
-
 public static class VoxelizationKernel
 {
-    // GPU-safe math implementations must reside inside this class
+    // GPU-safe math implementations
     private static int Min(int a, int b) => a < b ? a : b;
     private static int Max(int a, int b) => a > b ? a : b;
     private static float Min(float a, float b) => a < b ? a : b;
@@ -707,6 +707,15 @@ public static class VoxelizationKernel
         int maxY = Min(gridY - 1, Ceiling((tri.MaxBounds.Y - gridOrigin.Y) / cellSize));
         int maxZ = Min(gridZ - 1, Ceiling((tri.MaxBounds.Z - gridOrigin.Z) / cellSize));
 
+        // OPTIMIZATION 1: Precompute triangle edges and normal outside the loop
+        float e0X = tri.V1.X - tri.V0.X; float e0Y = tri.V1.Y - tri.V0.Y; float e0Z = tri.V1.Z - tri.V0.Z;
+        float e1X = tri.V2.X - tri.V1.X; float e1Y = tri.V2.Y - tri.V1.Y; float e1Z = tri.V2.Z - tri.V1.Z;
+        float e2X = tri.V0.X - tri.V2.X; float e2Y = tri.V0.Y - tri.V2.Y; float e2Z = tri.V0.Z - tri.V2.Z;
+
+        float normalX = e0Y * e1Z - e0Z * e1Y;
+        float normalY = e0Z * e1X - e0X * e1Z;
+        float normalZ = e0X * e1Y - e0Y * e1X;
+
         for (int z = minZ; z <= maxZ; z++)
         {
             for (int y = minY; y <= maxY; y++)
@@ -719,17 +728,29 @@ public static class VoxelizationKernel
                         gridOrigin.Z + (z + 0.5f) * cellSize
                     );
 
-                    if (CheckTriangleBoxIntersection(tri, cellCenter, cellSize))
+                    // Pass precomputed values into the intersection test
+                    if (CheckTriangleBoxIntersection(tri, cellCenter, cellSize,
+                        e0X, e0Y, e0Z, e1X, e1Y, e1Z, e2X, e2Y, e2Z, normalX, normalY, normalZ))
                     {
                         int flatIndex = x + (y * gridX) + (z * gridX * gridY);
-                        Atomic.Exchange(ref voxelGrid[flatIndex], 0);
+
+                        // OPTIMIZATION 2: Cache-friendly early exit prevents memory bus locking
+                        if (voxelGrid[flatIndex] != 0)
+                        {
+                            Atomic.Exchange(ref voxelGrid[flatIndex], 0);
+                        }
                     }
                 }
             }
         }
     }
 
-    private static bool CheckTriangleBoxIntersection(GpuTriangle tri, Float3 boxCenter, float cellSize)
+    private static bool CheckTriangleBoxIntersection(
+        GpuTriangle tri, Float3 boxCenter, float cellSize,
+        float e0X, float e0Y, float e0Z,
+        float e1X, float e1Y, float e1Z,
+        float e2X, float e2Y, float e2Z,
+        float normalX, float normalY, float normalZ)
     {
         float boxHalf = cellSize * 0.5f;
 
@@ -738,21 +759,12 @@ public static class VoxelizationKernel
         float v1X = tri.V1.X - boxCenter.X; float v1Y = tri.V1.Y - boxCenter.Y; float v1Z = tri.V1.Z - boxCenter.Z;
         float v2X = tri.V2.X - boxCenter.X; float v2Y = tri.V2.Y - boxCenter.Y; float v2Z = tri.V2.Z - boxCenter.Z;
 
-        // Compute edge vectors
-        float e0X = v1X - v0X; float e0Y = v1Y - v0Y; float e0Z = v1Z - v0Z;
-        float e1X = v2X - v1X; float e1Y = v2Y - v1Y; float e1Z = v2Z - v1Z;
-        float e2X = v0X - v2X; float e2Y = v0Y - v2Y; float e2Z = v0Z - v2Z;
-
         // SAT Test 1: Box AABB bounds
         if (Min3(v0X, v1X, v2X) > boxHalf || Max3(v0X, v1X, v2X) < -boxHalf) return false;
         if (Min3(v0Y, v1Y, v2Y) > boxHalf || Max3(v0Y, v1Y, v2Y) < -boxHalf) return false;
         if (Min3(v0Z, v1Z, v2Z) > boxHalf || Max3(v0Z, v1Z, v2Z) < -boxHalf) return false;
 
         // SAT Test 2: Triangle Plane vs Box Overlap
-        float normalX = e0Y * e1Z - e0Z * e1Y;
-        float normalY = e0Z * e1X - e0X * e1Z;
-        float normalZ = e0X * e1Y - e0Y * e1X;
-
         float d = -(normalX * v0X + normalY * v0Y + normalZ * v0Z);
 
         float vminX = normalX > 0f ? -boxHalf : boxHalf; float vmaxX = normalX > 0f ? boxHalf : -boxHalf;

--- a/Algorithms/GridShaper.cs
+++ b/Algorithms/GridShaper.cs
@@ -129,17 +129,6 @@ public class GridShaper
 
         long totalGridVolume = (long)gridX * gridY * gridZ;
 
-        if (totalGridVolume >= 67_108_864)
-        {
-            throw new Exception($"Model is too large for {settings.BlockSize} resolution!\n" +
-                                $"Requires {totalGridVolume:N0} blocks ({gridX}x{gridY}x{gridZ}).\n" +
-                                $"Please scale the model down or select a larger block size.");
-        }
-        if (this.Mesh.TriangleCount == 0)
-        {
-            throw new Exception("The selected model contains no 3D geometry.");
-        }
-
         var indexer = new ShiftGridIndexer3(bounds.Min, blockSize);
         var bmp = new DenseGrid3i(gridX, gridY, gridZ, BlueprintMesh.NoContent);
         int triangleCount = this.Mesh.TriangleCount;

--- a/Algorithms/GridShaper.cs
+++ b/Algorithms/GridShaper.cs
@@ -36,22 +36,41 @@ public class GridShaper
         this.Tree = tree;
     }
 
-    // Class to cache the GPU context and kernel globally
+    // Class to cache the GPU context and kernels globally
     public static class GpuSetup
     {
-        public static Context Context { get; }
-        public static Accelerator Accelerator { get; }
-        public static Action<Index1D, ArrayView<GpuTriangle>, ArrayView<int>, Float3, float, int, int, int> VoxelizeKernel { get; }
+        public static Context Context { get; private set; }
+        public static Accelerator Accelerator { get; private set; }
+        public static Action<Index1D, ArrayView<GpuTriangle>, ArrayView<int>, Float3, float, int, int, int> VoxelizeKernel { get; private set; }
+        public static Action<Index1D, ArrayView<int>, int> InitGridKernel { get; private set; }
+
+        public static readonly object SyncLock = new object();
 
         static GpuSetup()
         {
-            Context = Context.CreateDefault();
-            Accelerator = Context.GetPreferredDevice(preferCPU: false).CreateAccelerator(Context);
-            System.Diagnostics.Debug.WriteLine($"\n[ILGPU INITIALIZATION] Compiled and Cached on: {Accelerator.Name} (Type: {Accelerator.AcceleratorType})\n");
+            RebuildContext();
+        }
 
-            VoxelizeKernel = Accelerator.LoadAutoGroupedStreamKernel<
-                Index1D, ArrayView<GpuTriangle>, ArrayView<int>, Float3, float, int, int, int>(
-                VoxelizationKernel.Voxelize);
+        public static void RebuildContext()
+        {
+            lock (SyncLock)
+            {
+                // Force ILGPU to release all cached VRAM pools back to the OS
+                try { Accelerator?.Dispose(); } catch { }
+                try { Context?.Dispose(); } catch { }
+
+                Context = Context.CreateDefault();
+                Accelerator = Context.GetPreferredDevice(preferCPU: false).CreateAccelerator(Context);
+                System.Diagnostics.Debug.WriteLine($"\n[ILGPU INITIALIZATION] Compiled and Cached on: {Accelerator.Name} (Type: {Accelerator.AcceleratorType})\n");
+
+                VoxelizeKernel = Accelerator.LoadAutoGroupedStreamKernel<
+                    Index1D, ArrayView<GpuTriangle>, ArrayView<int>, Float3, float, int, int, int>(
+                    VoxelizationKernel.Voxelize);
+
+                InitGridKernel = Accelerator.LoadAutoGroupedStreamKernel<
+                    Index1D, ArrayView<int>, int>(
+                    VoxelizationKernel.InitializeGrid);
+            }
         }
     }
 
@@ -81,227 +100,190 @@ public class GridShaper
         ];
     }
 
+    // --- PUBLIC FACADES ---
+    // These methods are the entry points for generating a blueprint mesh, either using GPU acceleration or CPU processing.
     public BlueprintMesh Generate(GeneratorSettings settings, CancellationToken ct, IProgress<(double, string)> progress = null)
-    {
-        var blockSize = settings.BlockSize switch
-        {
-            BlockSizes.TwoPointFive => ShapeDB.LargeBlockSize,
-            BlockSizes.HalfMeter => ShapeDB.MidBlockSize
-        };
-
-        var minimalBounds = this.Tree.Bounds;
-        minimalBounds.Min -= blockSize;
-        minimalBounds.Max += blockSize;
-
-        var boundingBox = new g4.AxisAlignedBox3d(new g4.Vector3d(0), blockSize / 2);
-        while (boundingBox.Contains(minimalBounds) == false)
-        {
-            boundingBox.Scale(2, 2, 2);
-        }
-
-        var cellCount = (int)Math.Ceiling(boundingBox.MaxDim / blockSize);
-        var indexer = new ShiftGridIndexer3(boundingBox.Min, blockSize);
-
-        // Access the cached GPU environment instead of creating a new one
-        var accelerator = GpuSetup.Accelerator;
-        var voxelizeKernel = GpuSetup.VoxelizeKernel;
-        System.Diagnostics.Debug.WriteLine($"\n[ILGPU VERIFICATION] Executing on: {accelerator.Name} (Type: {accelerator.AcceleratorType})\n");
-
-        // Prepare Triangle Data
-        int triangleCount = this.Mesh.TriangleCount;
-        var flatTriangles = new GpuTriangle[triangleCount];
-        int tIndex = 0;
-
-        // PHASE 1: Triangles (0% - 10%)
-        foreach (var triangle in this.Mesh.EnumerateTriangles())
-        {
-            ct.ThrowIfCancellationRequested();
-            if (tIndex % 5000 == 0) progress?.Report((0.1 * ((double)tIndex / triangleCount), "Mesh Flattening..."));
-
-            var box = triangle.ToBox();
-            flatTriangles[tIndex++] = new GpuTriangle
-            {
-                V0 = new Float3((float)triangle.V0.x, (float)triangle.V0.y, (float)triangle.V0.z),
-                V1 = new Float3((float)triangle.V1.x, (float)triangle.V1.y, (float)triangle.V1.z),
-                V2 = new Float3((float)triangle.V2.x, (float)triangle.V2.y, (float)triangle.V2.z),
-                MinBounds = new Float3((float)box.Min.x, (float)box.Min.y, (float)box.Min.z),
-                MaxBounds = new Float3((float)box.Max.x, (float)box.Max.y, (float)box.Max.z)
-            };
-        }
-
-        using var deviceTriangles = accelerator.Allocate1D(flatTriangles);
-        int totalCells = cellCount * cellCount * cellCount;
-        int[] initialGrid = new int[totalCells];
-        Array.Fill(initialGrid, BlueprintMesh.NoContent);
-        using var deviceGrid = accelerator.Allocate1D(initialGrid);
-
-        Float3 origin = new Float3((float)boundingBox.Min.x, (float)boundingBox.Min.y, (float)boundingBox.Min.z);
-
-        voxelizeKernel(
-            deviceTriangles.IntExtent,
-            deviceTriangles.View,
-            deviceGrid.View,
-            origin,
-            blockSize,
-            cellCount,
-            cellCount,
-            cellCount
-        );
-
-        // PHASE 2: Voxelization (Jump to 40% after sync)
-        accelerator.Synchronize();
-        progress?.Report((0.40, "Voxelization..."));
-        var flatResults = deviceGrid.GetAsArray1D();
-
-        var bmp = new DenseGrid3i(cellCount, cellCount, cellCount, BlueprintMesh.NoContent);
-
-        // PHASE 3: Grid Reconstruction (40% - 70%)
-        int processedZ = 0;
-        var activeBlocks = new System.Collections.Concurrent.ConcurrentBag<g4.Vector3i>();
-        Parallel.For(0, cellCount, new ParallelOptions { CancellationToken = ct }, z =>
-        {
-            for (int y = 0; y < cellCount; y++)
-            {
-                for (int x = 0; x < cellCount; x++)
-                {
-                    int flatIdx = x + (y * cellCount) + (z * cellCount * cellCount);
-                    if (flatResults[flatIdx] == 0)
-                    {
-                        var cell = new g4.Vector3i(x, y, z);
-                        bmp[cell] = 0;
-                        activeBlocks.Add(cell);
-                    }
-                }
-            }
-
-            int currentZ = Interlocked.Increment(ref processedZ);
-            if (currentZ % 10 == 0)
-            {
-                progress?.Report((0.40 + (0.30 * ((double)currentZ / cellCount)), "Grid Reconstruction..."));
-            }
-        });
-
-        var blueprint = new BlueprintMesh();
-        blueprint.Blocks = bmp;
-        blueprint.Coords = indexer;
-        blueprint.Shapes = settings.BlockSize switch
-        {
-            BlockSizes.TwoPointFive => ShapeDB.LargeShapes,
-            BlockSizes.HalfMeter => ShapeDB.MidShapes
-        };
-
-        // PHASE 4: Slope Generation (70% - 100%)
-        progress?.Report((0.70, "Slope Evaluation..."));
-        int totalSlopePasses = (settings.SlopesUpper ? 4 : 0) + (settings.SlopesLower ? 4 : 0) + (settings.SlopesSides ? 4 : 0);
-        int executedPasses = 0;
-
-        if (settings.SlopesUpper) { ExecSlopes(1); ExecSlopes(2); ExecSlopes(3); ExecSlopes(4); }
-        if (settings.SlopesLower) { ExecSlopes(5); ExecSlopes(6); ExecSlopes(7); ExecSlopes(8); }
-        if (settings.SlopesSides) { ExecSlopes(9); ExecSlopes(10); ExecSlopes(11); ExecSlopes(12); }
-
-        void ExecSlopes(int content)
-        {
-            var shapeInfo = blueprint.Shapes[content];
-            var probeDirectionA = -Base6Directions.Vectors[shapeInfo.Forward];
-            var probeDirectionB = Base6Directions.Vectors[shapeInfo.Up];
-            var supportDirectionA = -probeDirectionA;
-            var supportDirectionB = -probeDirectionB;
-
-            // Multithreaded Slope Evaluation strictly over filled blocks
-            System.Threading.Tasks.Parallel.ForEach(activeBlocks, new System.Threading.Tasks.ParallelOptions { CancellationToken = ct }, g =>
-            {
-                if (blueprint[g] != 0) return; // 'return' breaks out of the lambda for this specific block
-
-                if (blueprint[g + probeDirectionA] != BlueprintMesh.NoContent || blueprint[g + probeDirectionB] != BlueprintMesh.NoContent)
-                {
-                    return;
-                }
-
-                if (settings.SlopesMustBeSupported)
-                {
-                    if (blueprint[g + supportDirectionA] != 0 || blueprint[g + supportDirectionB] != 0)
-                    {
-                        return;
-                    }
-                }
-
-                bmp[g] = content;
-            });
-
-            if (totalSlopePasses > 0)
-            {
-                int currentPass = System.Threading.Interlocked.Increment(ref executedPasses);
-                progress?.Report((0.70 + (0.30 * ((double)currentPass / totalSlopePasses)), "Slope Evaluation..."));
-            }
-        }
-
-        progress?.Report((1.0, "Complete, finalization!"));
-        return blueprint;
-    }
+        => CoreGenerate(settings, useGpu: true, ct, progress);
 
     public BlueprintMesh GenerateCpu(GeneratorSettings settings, CancellationToken ct, IProgress<(double, string)> progress = null)
+        => CoreGenerate(settings, useGpu: false, ct, progress);
+
+    // --- UNIFIED GENERATOR ---
+    private BlueprintMesh CoreGenerate(GeneratorSettings settings, bool useGpu, CancellationToken ct, IProgress<(double, string)> progress)
     {
+        // ==========================================
+        // PHASE 1: SHARED SETUP & GRID ALLOCATION
+        // ==========================================
         var blockSize = settings.BlockSize switch
         {
             BlockSizes.TwoPointFive => ShapeDB.LargeBlockSize,
             BlockSizes.HalfMeter => ShapeDB.MidBlockSize
         };
 
-        var minimalBounds = this.Tree.Bounds;
-        minimalBounds.Min -= blockSize;
-        minimalBounds.Max += blockSize;
+        var bounds = this.Tree.Bounds;
+        bounds.Expand(blockSize);
 
-        var boundingBox = new AxisAlignedBox3d(new Vector3d(0), blockSize / 2);
-        while (boundingBox.Contains(minimalBounds) == false)
+        int gridX = (int)Math.Ceiling(bounds.Width / blockSize);
+        int gridY = (int)Math.Ceiling(bounds.Height / blockSize);
+        int gridZ = (int)Math.Ceiling(bounds.Depth / blockSize);
+
+        long totalGridVolume = (long)gridX * gridY * gridZ;
+
+        if (totalGridVolume >= 67_108_864)
         {
-            boundingBox.Scale(2, 2, 2);
+            throw new Exception($"Model is too large for {settings.BlockSize} resolution!\n" +
+                                $"Requires {totalGridVolume:N0} blocks ({gridX}x{gridY}x{gridZ}).\n" +
+                                $"Please scale the model down or select a larger block size.");
+        }
+        if (this.Mesh.TriangleCount == 0)
+        {
+            throw new Exception("The selected model contains no 3D geometry.");
         }
 
-        System.Diagnostics.Debug.WriteLine($"\nExecuting the model to blueprint conversion on the CPU\n");
-        var cellCount = (int)Math.Ceiling(boundingBox.MaxDim / blockSize);
-        var indexer = new ShiftGridIndexer3(boundingBox.Min, blockSize);
+        var indexer = new ShiftGridIndexer3(bounds.Min, blockSize);
+        var bmp = new DenseGrid3i(gridX, gridY, gridZ, BlueprintMesh.NoContent);
+        int triangleCount = this.Mesh.TriangleCount;
 
-        var bmp = new DenseGrid3i(cellCount, cellCount, cellCount, BlueprintMesh.NoContent);
-
-        var blueprint = new BlueprintMesh();
-        blueprint.Blocks = bmp;
-        blueprint.Coords = indexer;
-        blueprint.Shapes = settings.BlockSize switch
+        var blueprint = new BlueprintMesh
         {
-            BlockSizes.TwoPointFive => ShapeDB.LargeShapes,
-            BlockSizes.HalfMeter => ShapeDB.MidShapes
+            Blocks = bmp,
+            Coords = indexer,
+            Shapes = settings.BlockSize switch
+            {
+                BlockSizes.TwoPointFive => ShapeDB.LargeShapes,
+                BlockSizes.HalfMeter => ShapeDB.MidShapes
+            }
         };
 
-        int triangleCount = this.Mesh.TriangleCount;
-        int tIndex = 0;
+        IEnumerable<Vector3i> activeBlocks;
 
-        foreach (var triangle in this.Mesh.EnumerateTriangles())
+        // ==========================================
+        // PHASE 2: VOXELIZATION (BRANCHING)
+        // ==========================================
+        if (useGpu)
         {
-            ct.ThrowIfCancellationRequested();
-            if (tIndex % 1000 == 0) progress?.Report((0.7 * ((double)tIndex / triangleCount), "Triangle Evaluation..."));
-            tIndex++;
+            Accelerator accelerator;
+            Action<Index1D, ArrayView<GpuTriangle>, ArrayView<int>, Float3, float, int, int, int> voxelizeKernel;
+            Action<Index1D, ArrayView<int>, int> initGridKernel;
 
-            var triBox = triangle.ToBox();
-            foreach (var cell in Enumerators.BoxRange(triBox, indexer))
+            lock (GpuSetup.SyncLock)
             {
-                var cellBox = indexer.ToBox(cell);
-                if (cellBox.IntersectWithTriangle(triangle) != IntersectResult.NoIntersection)
+                accelerator = GpuSetup.Accelerator;
+                voxelizeKernel = GpuSetup.VoxelizeKernel;
+                initGridKernel = GpuSetup.InitGridKernel;
+            }
+
+            System.Diagnostics.Debug.WriteLine($"\n[ILGPU VERIFICATION] Executing on: {accelerator.Name} (Type: {accelerator.AcceleratorType})\n");
+
+            var flatTriangles = new GpuTriangle[triangleCount];
+            int tIndex = 0;
+
+            foreach (var triangle in this.Mesh.EnumerateTriangles())
+            {
+                ct.ThrowIfCancellationRequested();
+                if (tIndex % 5000 == 0) progress?.Report((0.1 * ((double)tIndex / triangleCount), "Mesh Flattening..."));
+
+                var box = triangle.ToBox();
+                flatTriangles[tIndex++] = new GpuTriangle
                 {
-                    bmp[cell] = 0; //Cube
+                    V0 = new Float3((float)triangle.V0.x, (float)triangle.V0.y, (float)triangle.V0.z),
+                    V1 = new Float3((float)triangle.V1.x, (float)triangle.V1.y, (float)triangle.V1.z),
+                    V2 = new Float3((float)triangle.V2.x, (float)triangle.V2.y, (float)triangle.V2.z),
+                    MinBounds = new Float3((float)box.Min.x, (float)box.Min.y, (float)box.Min.z),
+                    MaxBounds = new Float3((float)box.Max.x, (float)box.Max.y, (float)box.Max.z)
+                };
+            }
+
+            int[] flatResults;
+            int totalCells = (int)totalGridVolume;
+
+            try
+            {
+                using var deviceTriangles = accelerator.Allocate1D(flatTriangles);
+                using var deviceGrid = accelerator.Allocate1D<int>(totalCells);
+
+                initGridKernel(totalCells, deviceGrid.View, BlueprintMesh.NoContent);
+
+                Float3 origin = new Float3((float)bounds.Min.x, (float)bounds.Min.y, (float)bounds.Min.z);
+
+                voxelizeKernel(deviceTriangles.IntExtent, deviceTriangles.View, deviceGrid.View, origin, blockSize, gridX, gridY, gridZ);
+
+                accelerator.Synchronize();
+                progress?.Report((0.40, "Voxelization..."));
+                flatResults = deviceGrid.GetAsArray1D();
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("The GPU driver failed during allocation. Out of VRAM or driver error.", ex);
+            }
+
+            _ = Task.Run(() => GpuSetup.RebuildContext());
+
+            int processedZ = 0;
+            var gpuActiveBlocks = new System.Collections.Concurrent.ConcurrentBag<Vector3i>();
+
+            Parallel.For(0, gridZ, new ParallelOptions { CancellationToken = ct }, z =>
+            {
+                for (int y = 0; y < gridY; y++)
+                {
+                    for (int x = 0; x < gridX; x++)
+                    {
+                        int flatIdx = x + (y * gridX) + (z * gridX * gridY);
+                        if (flatResults[flatIdx] == 0)
+                        {
+                            var cell = new Vector3i(x, y, z);
+                            bmp[cell] = 0;
+                            gpuActiveBlocks.Add(cell);
+                        }
+                    }
+                }
+
+                int currentZ = Interlocked.Increment(ref processedZ);
+                if (currentZ % 10 == 0)
+                {
+                    progress?.Report((0.40 + (0.30 * ((double)currentZ / gridZ)), "Grid Reconstruction..."));
+                }
+            });
+
+            activeBlocks = gpuActiveBlocks;
+        }
+        else
+        {
+            System.Diagnostics.Debug.WriteLine($"\nExecuting the model to blueprint conversion on the CPU\n");
+            int tIndex = 0;
+
+            foreach (var triangle in this.Mesh.EnumerateTriangles())
+            {
+                ct.ThrowIfCancellationRequested();
+                if (tIndex % 1000 == 0) progress?.Report((0.7 * ((double)tIndex / triangleCount), "Triangle Evaluation..."));
+                tIndex++;
+
+                var triBox = triangle.ToBox();
+                foreach (var cell in Enumerators.BoxRange(triBox, indexer))
+                {
+                    var cellBox = indexer.ToBox(cell);
+                    if (cellBox.IntersectWithTriangle(triangle) != IntersectResult.NoIntersection)
+                    {
+                        bmp[cell] = 0;
+                    }
                 }
             }
-        }
 
-        // OPTIMIZATION: Gather only the active blocks to eliminate millions of empty-space checks
-        var activeBlocks = new List<g4.Vector3i>();
-        foreach (var g in bmp.Indices())
-        {
-            if (bmp[g] == 0)
+            var cpuActiveBlocks = new List<Vector3i>();
+            foreach (var g in bmp.Indices())
             {
-                activeBlocks.Add(g);
+                if (bmp[g] == 0)
+                {
+                    cpuActiveBlocks.Add(g);
+                }
             }
+
+            activeBlocks = cpuActiveBlocks;
         }
 
+        // ==========================================
+        // PHASE 3: SHARED SLOPE GENERATION
+        // ==========================================
         progress?.Report((0.70, "Slope Evaluation..."));
         int totalSlopePasses = (settings.SlopesUpper ? 4 : 0) + (settings.SlopesLower ? 4 : 0) + (settings.SlopesSides ? 4 : 0);
         int executedPasses = 0;
@@ -318,8 +300,7 @@ public class GridShaper
             var supportDirectionA = -probeDirectionA;
             var supportDirectionB = -probeDirectionB;
 
-            // Multithreaded Slope Evaluation strictly over filled blocks
-            System.Threading.Tasks.Parallel.ForEach(activeBlocks, new System.Threading.Tasks.ParallelOptions { CancellationToken = ct }, g =>
+            Parallel.ForEach(activeBlocks, new ParallelOptions { CancellationToken = ct }, g =>
             {
                 if (blueprint[g] != 0) return;
 
@@ -341,12 +322,12 @@ public class GridShaper
 
             if (totalSlopePasses > 0)
             {
-                int currentPass = System.Threading.Interlocked.Increment(ref executedPasses);
+                int currentPass = Interlocked.Increment(ref executedPasses);
                 progress?.Report((0.70 + (0.30 * ((double)currentPass / totalSlopePasses)), "Slope Evaluation..."));
             }
         }
 
-        progress?.Report((1.0, "Complete!"));
+        progress?.Report((1.0, "Complete, finalization!"));
         return blueprint;
     }
 
@@ -393,7 +374,6 @@ public class GridShaper
             var cubesMesh = cubesSurfaceGenerator.Meshes[0];
             MeshTransforms.Scale(cubesMesh, blueprint.Coords.CellSize);
 
-            // Voxel generator generates around UnitZeroCentered, while indexer rounds down to corner
             var correctionOffset = blueprint.Coords.CellSize / 2;
             MeshTransforms.Translate(cubesMesh, blueprint.Coords.Origin + correctionOffset);
 
@@ -548,7 +528,6 @@ public class GridShaper
 
         public void Generate(BlueprintMesh blueprint, StringBuilder sb)
         {
-            //Prefab|PositionX|PositionY|PositionZ|ColorHUE|ColorSATURATION|ColorVALUE|OrientationFORWARD|OrientationUP|Integrity
             var blockGrid = blueprint.Blocks;
             foreach (var g in blockGrid.Indices())
             {
@@ -572,14 +551,12 @@ public class GridShaper
                 var gridPosition = ToInt(cube.Center / ShapeDB.SmallBlockSize);
                 gridPosition += PositionOffset
                 (
-                    //TODO:
                     blueprint.Shapes == ShapeDB.LargeShapes ?
                         new AxisAlignedBox3i(new Vector3i(-4, -4, -4), new Vector3i(5, 5, 5)) :
                         new AxisAlignedBox3i(new Vector3i(0, 0, 0), new Vector3i(1, 1, 1)),
                     forwardAxis,
                     upAxis
                 );
-
 
                 sb.Append(gridPosition.x);
                 sb.Append('|');
@@ -660,6 +637,11 @@ public class GridShaper
         private static int Floor(float val) => val < 0f ? (int)val - 1 : (int)val;
         private static int Ceiling(float val) => val > (int)val ? (int)val + 1 : (int)val;
 
+        public static void InitializeGrid(Index1D index, ArrayView<int> grid, int value)
+        {
+            grid[index] = value;
+        }
+
         public static void Voxelize(
             Index1D index,
             ArrayView<GpuTriangle> triangles,
@@ -680,7 +662,6 @@ public class GridShaper
             int maxY = Min(gridY - 1, Ceiling((tri.MaxBounds.Y - gridOrigin.Y) / cellSize));
             int maxZ = Min(gridZ - 1, Ceiling((tri.MaxBounds.Z - gridOrigin.Z) / cellSize));
 
-            // OPTIMIZATION 1: Precompute triangle edges and normal outside the loop
             float e0X = tri.V1.X - tri.V0.X; float e0Y = tri.V1.Y - tri.V0.Y; float e0Z = tri.V1.Z - tri.V0.Z;
             float e1X = tri.V2.X - tri.V1.X; float e1Y = tri.V2.Y - tri.V1.Y; float e1Z = tri.V2.Z - tri.V1.Z;
             float e2X = tri.V0.X - tri.V2.X; float e2Y = tri.V0.Y - tri.V2.Y; float e2Z = tri.V0.Z - tri.V2.Z;
@@ -701,13 +682,11 @@ public class GridShaper
                             gridOrigin.Z + (z + 0.5f) * cellSize
                         );
 
-                        // Pass precomputed values into the intersection test
                         if (CheckTriangleBoxIntersection(tri, cellCenter, cellSize,
                             e0X, e0Y, e0Z, e1X, e1Y, e1Z, e2X, e2Y, e2Z, normalX, normalY, normalZ))
                         {
                             int flatIndex = x + (y * gridX) + (z * gridX * gridY);
 
-                            // OPTIMIZATION 2: Cache-friendly early exit prevents memory bus locking
                             if (voxelGrid[flatIndex] != 0)
                             {
                                 Atomic.Exchange(ref voxelGrid[flatIndex], 0);
@@ -727,17 +706,14 @@ public class GridShaper
         {
             float boxHalf = cellSize * 0.5f;
 
-            // Shift triangle to local AABB coordinate space
             float v0X = tri.V0.X - boxCenter.X; float v0Y = tri.V0.Y - boxCenter.Y; float v0Z = tri.V0.Z - boxCenter.Z;
             float v1X = tri.V1.X - boxCenter.X; float v1Y = tri.V1.Y - boxCenter.Y; float v1Z = tri.V1.Z - boxCenter.Z;
             float v2X = tri.V2.X - boxCenter.X; float v2Y = tri.V2.Y - boxCenter.Y; float v2Z = tri.V2.Z - boxCenter.Z;
 
-            // SAT Test 1: Box AABB bounds
             if (Min3(v0X, v1X, v2X) > boxHalf || Max3(v0X, v1X, v2X) < -boxHalf) return false;
             if (Min3(v0Y, v1Y, v2Y) > boxHalf || Max3(v0Y, v1Y, v2Y) < -boxHalf) return false;
             if (Min3(v0Z, v1Z, v2Z) > boxHalf || Max3(v0Z, v1Z, v2Z) < -boxHalf) return false;
 
-            // SAT Test 2: Triangle Plane vs Box Overlap
             float d = -(normalX * v0X + normalY * v0Y + normalZ * v0Z);
 
             float vminX = normalX > 0f ? -boxHalf : boxHalf; float vmaxX = normalX > 0f ? boxHalf : -boxHalf;
@@ -747,7 +723,6 @@ public class GridShaper
             if ((normalX * vminX + normalY * vminY + normalZ * vminZ) + d > 0f) return false;
             if ((normalX * vmaxX + normalY * vmaxY + normalZ * vmaxZ) + d < 0f) return false;
 
-            // SAT Test 3: Edge Cross Products
             if (!AxisTest(e0Z, -e0Y, v0Y, v0Z, v2Y, v2Z, boxHalf)) return false;
             if (!AxisTest(e1Z, -e1Y, v1Y, v1Z, v0Y, v0Z, boxHalf)) return false;
             if (!AxisTest(e2Z, -e2Y, v2Y, v2Z, v1Y, v1Z, boxHalf)) return false;

--- a/Algorithms/GridShaper.cs
+++ b/Algorithms/GridShaper.cs
@@ -4,6 +4,7 @@ using ILGPU.Runtime;
 using PropertyTools.DataAnnotations;
 using SpaceEditor.Rocks;
 using System.IO;
+using System.Runtime;
 using System.Text;
 
 namespace SpaceEditor.Algorithms;
@@ -25,6 +26,18 @@ public struct GpuTriangle
     public Float3 MaxBounds;
 }
 
+// Struct to bypass the C# 16-parameter limit for delegates
+public struct GpuSlopeParams
+{
+    public int GridX, GridY, GridZ;
+    public int PAx, PAy, PAz;
+    public int PBx, PBy, PBz;
+    public int SAx, SAy, SAz;
+    public int SBx, SBy, SBz;
+    public int Content;
+    public int MustBeSupported;
+}
+
 public class GridShaper
 {
     public DMesh3 Mesh { get; }
@@ -43,6 +56,7 @@ public class GridShaper
         public static Accelerator Accelerator { get; private set; }
         public static Action<Index1D, ArrayView<GpuTriangle>, ArrayView<int>, Float3, float, int, int, int> VoxelizeKernel { get; private set; }
         public static Action<Index1D, ArrayView<int>, int> InitGridKernel { get; private set; }
+        public static Action<Index1D, ArrayView<int>, GpuSlopeParams> SlopeKernel { get; private set; }
 
         public static readonly object SyncLock = new object();
 
@@ -70,6 +84,10 @@ public class GridShaper
                 InitGridKernel = Accelerator.LoadAutoGroupedStreamKernel<
                     Index1D, ArrayView<int>, int>(
                     VoxelizationKernel.InitializeGrid);
+
+                SlopeKernel = Accelerator.LoadAutoGroupedStreamKernel<
+                    Index1D, ArrayView<int>, GpuSlopeParams>(
+                    VoxelizationKernel.GenerateSlopes);
             }
         }
     }
@@ -107,6 +125,7 @@ public class GridShaper
 
     public BlueprintMesh GenerateCpu(GeneratorSettings settings, CancellationToken ct, IProgress<(double, string)> progress = null)
         => CoreGenerate(settings, useGpu: false, ct, progress);
+
 
     // --- UNIFIED GENERATOR ---
     private BlueprintMesh CoreGenerate(GeneratorSettings settings, bool useGpu, CancellationToken ct, IProgress<(double, string)> progress)
@@ -147,19 +166,21 @@ public class GridShaper
         IEnumerable<Vector3i> activeBlocks;
 
         // ==========================================
-        // PHASE 2: VOXELIZATION (BRANCHING)
+        // PHASE 2 & 3: GPU VOXELIZATION & SLOPE GENERATION
         // ==========================================
         if (useGpu)
         {
             Accelerator accelerator;
             Action<Index1D, ArrayView<GpuTriangle>, ArrayView<int>, Float3, float, int, int, int> voxelizeKernel;
             Action<Index1D, ArrayView<int>, int> initGridKernel;
+            Action<Index1D, ArrayView<int>, GpuSlopeParams> slopeKernel;
 
             lock (GpuSetup.SyncLock)
             {
                 accelerator = GpuSetup.Accelerator;
                 voxelizeKernel = GpuSetup.VoxelizeKernel;
                 initGridKernel = GpuSetup.InitGridKernel;
+                slopeKernel = GpuSetup.SlopeKernel;
             }
 
             System.Diagnostics.Debug.WriteLine($"\n[ILGPU VERIFICATION] Executing on: {accelerator.Name} (Type: {accelerator.AcceleratorType})\n");
@@ -183,7 +204,6 @@ public class GridShaper
                 };
             }
 
-            int[] flatResults;
             int totalCells = (int)totalGridVolume;
 
             try
@@ -196,45 +216,90 @@ public class GridShaper
                 Float3 origin = new Float3((float)bounds.Min.x, (float)bounds.Min.y, (float)bounds.Min.z);
 
                 voxelizeKernel(deviceTriangles.IntExtent, deviceTriangles.View, deviceGrid.View, origin, blockSize, gridX, gridY, gridZ);
-
                 accelerator.Synchronize();
-                progress?.Report((0.40, "Voxelization..."));
-                flatResults = deviceGrid.GetAsArray1D();
-            }
-            catch (Exception ex)
-            {
-                throw new Exception("The GPU driver failed during allocation. Out of VRAM or driver error.", ex);
-            }
+                progress?.Report((0.40, "Voxelization complete on GPU..."));
 
-            _ = Task.Run(() => GpuSetup.RebuildContext());
+                int totalSlopePasses = (settings.SlopesUpper ? 4 : 0) + (settings.SlopesLower ? 4 : 0) + (settings.SlopesSides ? 4 : 0);
+                int executedPasses = 0;
 
-            int processedZ = 0;
-            var gpuActiveBlocks = new System.Collections.Concurrent.ConcurrentBag<Vector3i>();
-
-            Parallel.For(0, gridZ, new ParallelOptions { CancellationToken = ct }, z =>
-            {
-                for (int y = 0; y < gridY; y++)
+                void ExecGpuSlopes(int content)
                 {
-                    for (int x = 0; x < gridX; x++)
+                    var shapeInfo = blueprint.Shapes[content];
+                    var probeDirectionA = -Base6Directions.Vectors[shapeInfo.Forward];
+                    var probeDirectionB = Base6Directions.Vectors[shapeInfo.Up];
+                    var supportDirectionA = -probeDirectionA;
+                    var supportDirectionB = -probeDirectionB;
+
+                    var slopeParams = new GpuSlopeParams
                     {
-                        int flatIdx = x + (y * gridX) + (z * gridX * gridY);
-                        if (flatResults[flatIdx] == 0)
-                        {
-                            var cell = new Vector3i(x, y, z);
-                            bmp[cell] = 0;
-                            gpuActiveBlocks.Add(cell);
-                        }
+                        GridX = gridX,
+                        GridY = gridY,
+                        GridZ = gridZ,
+                        PAx = probeDirectionA.x,
+                        PAy = probeDirectionA.y,
+                        PAz = probeDirectionA.z,
+                        PBx = probeDirectionB.x,
+                        PBy = probeDirectionB.y,
+                        PBz = probeDirectionB.z,
+                        SAx = supportDirectionA.x,
+                        SAy = supportDirectionA.y,
+                        SAz = supportDirectionA.z,
+                        SBx = supportDirectionB.x,
+                        SBy = supportDirectionB.y,
+                        SBz = supportDirectionB.z,
+                        Content = content,
+                        MustBeSupported = settings.SlopesMustBeSupported ? 1 : 0
+                    };
+
+                    slopeKernel(totalCells, deviceGrid.View, slopeParams);
+                    accelerator.Synchronize();
+
+                    if (totalSlopePasses > 0)
+                    {
+                        int currentPass = Interlocked.Increment(ref executedPasses);
+                        progress?.Report((0.40 + (0.30 * ((double)currentPass / totalSlopePasses)), "GPU Slope Evaluation..."));
                     }
                 }
 
-                int currentZ = Interlocked.Increment(ref processedZ);
-                if (currentZ % 10 == 0)
-                {
-                    progress?.Report((0.40 + (0.30 * ((double)currentZ / gridZ)), "Grid Reconstruction..."));
-                }
-            });
+                if (settings.SlopesUpper) { ExecGpuSlopes(1); ExecGpuSlopes(2); ExecGpuSlopes(3); ExecGpuSlopes(4); }
+                if (settings.SlopesLower) { ExecGpuSlopes(5); ExecGpuSlopes(6); ExecGpuSlopes(7); ExecGpuSlopes(8); }
+                if (settings.SlopesSides) { ExecGpuSlopes(9); ExecGpuSlopes(10); ExecGpuSlopes(11); ExecGpuSlopes(12); }
 
-            activeBlocks = gpuActiveBlocks;
+                int[] flatResults = deviceGrid.GetAsArray1D();
+                _ = Task.Run(() => GpuSetup.RebuildContext());
+
+                int processedZ = 0;
+                var gpuActiveBlocks = new System.Collections.Concurrent.ConcurrentBag<Vector3i>();
+
+                Parallel.For(0, gridZ, new ParallelOptions { CancellationToken = ct }, z =>
+                {
+                    for (int y = 0; y < gridY; y++)
+                    {
+                        for (int x = 0; x < gridX; x++)
+                        {
+                            int flatIdx = x + (y * gridX) + (z * gridX * gridY);
+                            if (flatResults[flatIdx] != BlueprintMesh.NoContent)
+                            {
+                                var cell = new Vector3i(x, y, z);
+                                bmp[cell] = flatResults[flatIdx];
+                                gpuActiveBlocks.Add(cell);
+                            }
+                        }
+                    }
+
+                    int currentZ = Interlocked.Increment(ref processedZ);
+                    if (currentZ % 10 == 0)
+                    {
+                        progress?.Report((0.70 + (0.30 * ((double)currentZ / gridZ)), "Grid Reconstruction..."));
+                    }
+                });
+
+                activeBlocks = gpuActiveBlocks;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("The GPU driver failed during allocation or kernel execution. Out of VRAM or driver error.", ex);
+            }
         }
         else
         {
@@ -268,58 +333,64 @@ public class GridShaper
             }
 
             activeBlocks = cpuActiveBlocks;
-        }
 
-        // ==========================================
-        // PHASE 3: SHARED SLOPE GENERATION
-        // ==========================================
-        progress?.Report((0.70, "Slope Evaluation..."));
-        int totalSlopePasses = (settings.SlopesUpper ? 4 : 0) + (settings.SlopesLower ? 4 : 0) + (settings.SlopesSides ? 4 : 0);
-        int executedPasses = 0;
+            progress?.Report((0.70, "Slope Evaluation..."));
+            int totalSlopePasses = (settings.SlopesUpper ? 4 : 0) + (settings.SlopesLower ? 4 : 0) + (settings.SlopesSides ? 4 : 0);
+            int executedPasses = 0;
 
-        if (settings.SlopesUpper) { ExecSlopes(1); ExecSlopes(2); ExecSlopes(3); ExecSlopes(4); }
-        if (settings.SlopesLower) { ExecSlopes(5); ExecSlopes(6); ExecSlopes(7); ExecSlopes(8); }
-        if (settings.SlopesSides) { ExecSlopes(9); ExecSlopes(10); ExecSlopes(11); ExecSlopes(12); }
+            if (settings.SlopesUpper) { ExecCpuSlopes(1); ExecCpuSlopes(2); ExecCpuSlopes(3); ExecCpuSlopes(4); }
+            if (settings.SlopesLower) { ExecCpuSlopes(5); ExecCpuSlopes(6); ExecCpuSlopes(7); ExecCpuSlopes(8); }
+            if (settings.SlopesSides) { ExecCpuSlopes(9); ExecCpuSlopes(10); ExecCpuSlopes(11); ExecCpuSlopes(12); }
 
-        void ExecSlopes(int content)
-        {
-            var shapeInfo = blueprint.Shapes[content];
-            var probeDirectionA = -Base6Directions.Vectors[shapeInfo.Forward];
-            var probeDirectionB = Base6Directions.Vectors[shapeInfo.Up];
-            var supportDirectionA = -probeDirectionA;
-            var supportDirectionB = -probeDirectionB;
-
-            Parallel.ForEach(activeBlocks, new ParallelOptions { CancellationToken = ct }, g =>
+            void ExecCpuSlopes(int content)
             {
-                if (blueprint[g] != 0) return;
+                var shapeInfo = blueprint.Shapes[content];
+                var probeDirectionA = -Base6Directions.Vectors[shapeInfo.Forward];
+                var probeDirectionB = Base6Directions.Vectors[shapeInfo.Up];
+                var supportDirectionA = -probeDirectionA;
+                var supportDirectionB = -probeDirectionB;
 
-                if (blueprint[g + probeDirectionA] != BlueprintMesh.NoContent || blueprint[g + probeDirectionB] != BlueprintMesh.NoContent)
+                Parallel.ForEach(activeBlocks, new ParallelOptions { CancellationToken = ct }, g =>
                 {
-                    return;
-                }
+                    if (blueprint[g] != 0) return;
 
-                if (settings.SlopesMustBeSupported)
-                {
-                    if (blueprint[g + supportDirectionA] != 0 || blueprint[g + supportDirectionB] != 0)
+                    if (blueprint[g + probeDirectionA] != BlueprintMesh.NoContent || blueprint[g + probeDirectionB] != BlueprintMesh.NoContent)
                     {
                         return;
                     }
+
+                    if (settings.SlopesMustBeSupported)
+                    {
+                        if (blueprint[g + supportDirectionA] != 0 || blueprint[g + supportDirectionB] != 0)
+                        {
+                            return;
+                        }
+                    }
+
+                    bmp[g] = content;
+                });
+
+                if (totalSlopePasses > 0)
+                {
+                    int currentPass = Interlocked.Increment(ref executedPasses);
+                    progress?.Report((0.70 + (0.30 * ((double)currentPass / totalSlopePasses)), "Slope Evaluation..."));
                 }
-
-                bmp[g] = content;
-            });
-
-            if (totalSlopePasses > 0)
-            {
-                int currentPass = Interlocked.Increment(ref executedPasses);
-                progress?.Report((0.70 + (0.30 * ((double)currentPass / totalSlopePasses)), "Slope Evaluation..."));
             }
         }
+
+        // Forcing the .NET runtime to compact the LOH and free up memory after the voxelization and slope generation, watch this space in case it hurts performance
+        GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
+        GC.Collect(2, GCCollectionMode.Aggressive, blocking: true, compacting: true);
 
         progress?.Report((1.0, "Complete, finalization!"));
         return blueprint;
     }
 
+
+    // ==========================================
+    // PHASE 4: CPU MESHING & FINALIZATION 
+    // (Handles VoxelSurfaceGenerator, Marching Cubes, and Text Export)
+    // ==========================================
     public class GridMesher
     {
         public static DMesh3 Mesh(BlueprintMesh blueprint)
@@ -366,7 +437,6 @@ public class GridShaper
             var correctionOffset = blueprint.Coords.CellSize / 2;
             MeshTransforms.Translate(cubesMesh, blueprint.Coords.Origin + correctionOffset);
 
-
             var finalMesh = cubesMesh;
             finalMesh.AppendMesh(slopeMesh);
 
@@ -399,10 +469,8 @@ public class GridShaper
 
         public static ShapeDB LargeShapes = new
         (
-            // Cube
             CubicShape("2eacbbf2-d8fb-4a78-91dc-7b492517ef97", x => x.AppendBox(Dims(LargeBlockSize))),
 
-            // Slopes
             SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Left, Base6Directions.Up),
             SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Right, Base6Directions.Up),
             SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Forward, Base6Directions.Up),
@@ -421,10 +489,8 @@ public class GridShaper
 
         public static ShapeDB MidShapes = new
         (
-            // Cube
             CubicShape("632d7385-12b9-47a6-802a-a610d0cbd1e0", x => x.AppendBox(Dims(MidBlockSize))),
 
-            // Slopes
             SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Left, Base6Directions.Up),
             SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Right, Base6Directions.Up),
             SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Forward, Base6Directions.Up),
@@ -615,7 +681,6 @@ public class GridShaper
 
     public static class VoxelizationKernel
     {
-        // GPU-safe math implementations
         private static int Min(int a, int b) => a < b ? a : b;
         private static int Max(int a, int b) => a > b ? a : b;
         private static float Min(float a, float b) => a < b ? a : b;
@@ -684,6 +749,47 @@ public class GridShaper
                     }
                 }
             }
+        }
+
+        public static void GenerateSlopes(
+            Index1D index,
+            ArrayView<int> voxelGrid,
+            GpuSlopeParams p)
+        {
+            int x = index % p.GridX;
+            int y = (index / p.GridX) % p.GridY;
+            int z = index / (p.GridX * p.GridY);
+
+            if (voxelGrid[index] != 0) return;
+
+            int nxA = x + p.PAx; int nyA = y + p.PAy; int nzA = z + p.PAz;
+            int nxB = x + p.PBx; int nyB = y + p.PBy; int nzB = z + p.PBz;
+
+            if (nxA < 0 || nxA >= p.GridX || nyA < 0 || nyA >= p.GridY || nzA < 0 || nzA >= p.GridZ) return;
+            if (nxB < 0 || nxB >= p.GridX || nyB < 0 || nyB >= p.GridY || nzB < 0 || nzB >= p.GridZ) return;
+
+            int idxA = nxA + (nyA * p.GridX) + (nzA * p.GridX * p.GridY);
+            int idxB = nxB + (nyB * p.GridX) + (nzB * p.GridX * p.GridY);
+
+            if (voxelGrid[idxA] != int.MaxValue || voxelGrid[idxB] != int.MaxValue)
+                return;
+
+            if (p.MustBeSupported == 1)
+            {
+                int sxA = x + p.SAx; int syA = y + p.SAy; int szA = z + p.SAz;
+                int sxB = x + p.SBx; int syB = y + p.SBy; int szB = z + p.SBz;
+
+                if (sxA < 0 || sxA >= p.GridX || syA < 0 || syA >= p.GridY || szA < 0 || szA >= p.GridZ) return;
+                if (sxB < 0 || sxB >= p.GridX || syB < 0 || syB >= p.GridY || szB < 0 || szB >= p.GridZ) return;
+
+                int sIdxA = sxA + (syA * p.GridX) + (szA * p.GridX * p.GridY);
+                int sIdxB = sxB + (syB * p.GridX) + (szB * p.GridX * p.GridY);
+
+                if (voxelGrid[sIdxA] != 0 || voxelGrid[sIdxB] != 0)
+                    return;
+            }
+
+            Atomic.Exchange(ref voxelGrid[index], p.Content);
         }
 
         private static bool CheckTriangleBoxIntersection(

--- a/Algorithms/GridShaper.cs
+++ b/Algorithms/GridShaper.cs
@@ -1,16 +1,9 @@
-﻿using Assimp;
-using g4;
+﻿using g4;
 using ILGPU;
 using ILGPU.Runtime;
 using PropertyTools.DataAnnotations;
-using SpaceEditor.Algorithms;
 using SpaceEditor.Rocks;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Numerics;
 using System.Text;
 
 namespace SpaceEditor.Algorithms;
@@ -43,10 +36,29 @@ public class GridShaper
         this.Tree = tree;
     }
 
+    // Class to cache the GPU context and kernel globally
+    public static class GpuSetup
+    {
+        public static Context Context { get; }
+        public static Accelerator Accelerator { get; }
+        public static Action<Index1D, ArrayView<GpuTriangle>, ArrayView<int>, Float3, float, int, int, int> VoxelizeKernel { get; }
+
+        static GpuSetup()
+        {
+            Context = Context.CreateDefault();
+            Accelerator = Context.GetPreferredDevice(preferCPU: false).CreateAccelerator(Context);
+            System.Diagnostics.Debug.WriteLine($"\n[ILGPU INITIALIZATION] Compiled and Cached on: {Accelerator.Name} (Type: {Accelerator.AcceleratorType})\n");
+
+            VoxelizeKernel = Accelerator.LoadAutoGroupedStreamKernel<
+                Index1D, ArrayView<GpuTriangle>, ArrayView<int>, Float3, float, int, int, int>(
+                VoxelizationKernel.Voxelize);
+        }
+    }
+
     public static class BlockSizes
     {
         public const string TwoPointFive = "2.5m";
-        public const string HalfMeter = "0.5m (VERY VERY slow on large ships!)";
+        public const string HalfMeter = "0.5m (May be slow on large ships!)";
         public const string TwentyFiveC = nameof(TwentyFiveC);
     }
 
@@ -90,9 +102,9 @@ public class GridShaper
         var cellCount = (int)Math.Ceiling(boundingBox.MaxDim / blockSize);
         var indexer = new ShiftGridIndexer3(boundingBox.Min, blockSize);
 
-        // Initialize ILGPU Context
-        using var context = Context.CreateDefault();
-        using var accelerator = context.GetPreferredDevice(preferCPU: false).CreateAccelerator(context);
+        // Access the cached GPU environment instead of creating a new one
+        var accelerator = GpuSetup.Accelerator;
+        var voxelizeKernel = GpuSetup.VoxelizeKernel;
         System.Diagnostics.Debug.WriteLine($"\n[ILGPU VERIFICATION] Executing on: {accelerator.Name} (Type: {accelerator.AcceleratorType})\n");
 
         // Prepare Triangle Data
@@ -104,7 +116,6 @@ public class GridShaper
         foreach (var triangle in this.Mesh.EnumerateTriangles())
         {
             ct.ThrowIfCancellationRequested();
-            // Report progress periodically to avoid UI thread spam
             if (tIndex % 5000 == 0) progress?.Report((0.1 * ((double)tIndex / triangleCount), "Mesh Flattening..."));
 
             var box = triangle.ToBox();
@@ -118,23 +129,14 @@ public class GridShaper
             };
         }
 
-        // Allocate GPU Memory
         using var deviceTriangles = accelerator.Allocate1D(flatTriangles);
-
-        // Flat 1D representation of the 3D voxel grid
         int totalCells = cellCount * cellCount * cellCount;
         int[] initialGrid = new int[totalCells];
         Array.Fill(initialGrid, BlueprintMesh.NoContent);
         using var deviceGrid = accelerator.Allocate1D(initialGrid);
 
-        // Load and compile kernel
-        var voxelizeKernel = accelerator.LoadAutoGroupedStreamKernel<
-            Index1D, ArrayView<GpuTriangle>, ArrayView<int>, Float3, float, int, int, int>(
-            VoxelizationKernel.Voxelize);
-
         Float3 origin = new Float3((float)boundingBox.Min.x, (float)boundingBox.Min.y, (float)boundingBox.Min.z);
 
-        // Dispatch execution to the GPU
         voxelizeKernel(
             deviceTriangles.IntExtent,
             deviceTriangles.View,
@@ -151,15 +153,13 @@ public class GridShaper
         progress?.Report((0.40, "Voxelization..."));
         var flatResults = deviceGrid.GetAsArray1D();
 
-        // Reconstruct the internal BlueprintMesh data structure
         var bmp = new DenseGrid3i(cellCount, cellCount, cellCount, BlueprintMesh.NoContent);
 
         // PHASE 3: Grid Reconstruction (40% - 70%)
-        for (int z = 0; z < cellCount; z++)
+        int processedZ = 0;
+        var activeBlocks = new System.Collections.Concurrent.ConcurrentBag<g4.Vector3i>();
+        Parallel.For(0, cellCount, new ParallelOptions { CancellationToken = ct }, z =>
         {
-            ct.ThrowIfCancellationRequested();
-            if (z % 10 == 0) progress?.Report((0.40 + (0.30 * ((double)z / cellCount)), "Grid Reconstruction..."));
-
             for (int y = 0; y < cellCount; y++)
             {
                 for (int x = 0; x < cellCount; x++)
@@ -167,11 +167,19 @@ public class GridShaper
                     int flatIdx = x + (y * cellCount) + (z * cellCount * cellCount);
                     if (flatResults[flatIdx] == 0)
                     {
-                        bmp[new g4.Vector3i(x, y, z)] = 0;
+                        var cell = new g4.Vector3i(x, y, z);
+                        bmp[cell] = 0;
+                        activeBlocks.Add(cell);
                     }
                 }
             }
-        }
+
+            int currentZ = Interlocked.Increment(ref processedZ);
+            if (currentZ % 10 == 0)
+            {
+                progress?.Report((0.40 + (0.30 * ((double)currentZ / cellCount)), "Grid Reconstruction..."));
+            }
+        });
 
         var blueprint = new BlueprintMesh();
         blueprint.Blocks = bmp;
@@ -183,33 +191,13 @@ public class GridShaper
         };
 
         // PHASE 4: Slope Generation (70% - 100%)
-        progress?.Report((0.70, "Slope Evaluation...")); 
+        progress?.Report((0.70, "Slope Evaluation..."));
         int totalSlopePasses = (settings.SlopesUpper ? 4 : 0) + (settings.SlopesLower ? 4 : 0) + (settings.SlopesSides ? 4 : 0);
         int executedPasses = 0;
 
-        if (settings.SlopesUpper)
-        {
-            ExecSlopes(1);
-            ExecSlopes(2);
-            ExecSlopes(3);
-            ExecSlopes(4);
-        }
-
-        if (settings.SlopesLower)
-        {
-            ExecSlopes(5);
-            ExecSlopes(6);
-            ExecSlopes(7);
-            ExecSlopes(8);
-        }
-
-        if (settings.SlopesSides)
-        {
-            ExecSlopes(9);
-            ExecSlopes(10);
-            ExecSlopes(11);
-            ExecSlopes(12);
-        }
+        if (settings.SlopesUpper) { ExecSlopes(1); ExecSlopes(2); ExecSlopes(3); ExecSlopes(4); }
+        if (settings.SlopesLower) { ExecSlopes(5); ExecSlopes(6); ExecSlopes(7); ExecSlopes(8); }
+        if (settings.SlopesSides) { ExecSlopes(9); ExecSlopes(10); ExecSlopes(11); ExecSlopes(12); }
 
         void ExecSlopes(int content)
         {
@@ -219,42 +207,38 @@ public class GridShaper
             var supportDirectionA = -probeDirectionA;
             var supportDirectionB = -probeDirectionB;
 
-            foreach (var g in bmp.Indices())
+            // Multithreaded Slope Evaluation strictly over filled blocks
+            System.Threading.Tasks.Parallel.ForEach(activeBlocks, new System.Threading.Tasks.ParallelOptions { CancellationToken = ct }, g =>
             {
-                ct.ThrowIfCancellationRequested();
+                if (blueprint[g] != 0) return; // 'return' breaks out of the lambda for this specific block
 
-                if (blueprint[g] != 0) continue;
-
-                if(blueprint[g + probeDirectionA] != BlueprintMesh.NoContent ||blueprint[g + probeDirectionB] != BlueprintMesh.NoContent)
+                if (blueprint[g + probeDirectionA] != BlueprintMesh.NoContent || blueprint[g + probeDirectionB] != BlueprintMesh.NoContent)
                 {
-                    continue;
+                    return;
                 }
 
                 if (settings.SlopesMustBeSupported)
                 {
-                    ct.ThrowIfCancellationRequested();
-                    if(blueprint[g + supportDirectionA] != 0 || blueprint[g + supportDirectionB] != 0)
+                    if (blueprint[g + supportDirectionA] != 0 || blueprint[g + supportDirectionB] != 0)
                     {
-                        continue;
+                        return;
                     }
                 }
 
                 bmp[g] = content;
+            });
+
+            if (totalSlopePasses > 0)
+            {
+                int currentPass = System.Threading.Interlocked.Increment(ref executedPasses);
+                progress?.Report((0.70 + (0.30 * ((double)currentPass / totalSlopePasses)), "Slope Evaluation..."));
             }
         }
 
-        // Report progress after each directional pass completes
-        if (totalSlopePasses > 0)
-        {
-            executedPasses++;
-            progress?.Report((0.70 + (0.30 * ((double)executedPasses / totalSlopePasses)), "Slope Evaluation..."));
-        }
-
-        progress?.Report((1.0, "Complete!"));
+        progress?.Report((1.0, "Complete, finalization!"));
         return blueprint;
     }
 
-    //Old, CPU based rendering. Kept here as a legacy option, in case using the GPU is not feasible for some reason. It is significantly slower than the GPU version, especially for large meshes.
     public BlueprintMesh GenerateCpu(GeneratorSettings settings, CancellationToken ct, IProgress<(double, string)> progress = null)
     {
         var blockSize = settings.BlockSize switch
@@ -266,18 +250,19 @@ public class GridShaper
         var minimalBounds = this.Tree.Bounds;
         minimalBounds.Min -= blockSize;
         minimalBounds.Max += blockSize;
-        
+
         var boundingBox = new AxisAlignedBox3d(new Vector3d(0), blockSize / 2);
         while (boundingBox.Contains(minimalBounds) == false)
         {
             boundingBox.Scale(2, 2, 2);
         }
 
-        var cellCount = (int) Math.Ceiling(boundingBox.MaxDim / blockSize);
+        System.Diagnostics.Debug.WriteLine($"\nExecuting the model to blueprint conversion on the CPU\n");
+        var cellCount = (int)Math.Ceiling(boundingBox.MaxDim / blockSize);
         var indexer = new ShiftGridIndexer3(boundingBox.Min, blockSize);
 
         var bmp = new DenseGrid3i(cellCount, cellCount, cellCount, BlueprintMesh.NoContent);
-        
+
         var blueprint = new BlueprintMesh();
         blueprint.Blocks = bmp;
         blueprint.Coords = indexer;
@@ -307,33 +292,23 @@ public class GridShaper
             }
         }
 
-        progress?.Report((0.70, "Dispatch & Execution..."));
+        // OPTIMIZATION: Gather only the active blocks to eliminate millions of empty-space checks
+        var activeBlocks = new List<g4.Vector3i>();
+        foreach (var g in bmp.Indices())
+        {
+            if (bmp[g] == 0)
+            {
+                activeBlocks.Add(g);
+            }
+        }
+
+        progress?.Report((0.70, "Slope Evaluation..."));
         int totalSlopePasses = (settings.SlopesUpper ? 4 : 0) + (settings.SlopesLower ? 4 : 0) + (settings.SlopesSides ? 4 : 0);
         int executedPasses = 0;
 
-        if (settings.SlopesUpper)
-        {
-            ExecSlopes(1);
-            ExecSlopes(2);
-            ExecSlopes(3);
-            ExecSlopes(4);
-        }
-
-        if (settings.SlopesLower)
-        {
-            ExecSlopes(5);
-            ExecSlopes(6);
-            ExecSlopes(7);
-            ExecSlopes(8);
-        }
-
-        if (settings.SlopesSides)
-        {
-            ExecSlopes(9);
-            ExecSlopes(10);
-            ExecSlopes(11);
-            ExecSlopes(12);
-        }
+        if (settings.SlopesUpper) { ExecSlopes(1); ExecSlopes(2); ExecSlopes(3); ExecSlopes(4); }
+        if (settings.SlopesLower) { ExecSlopes(5); ExecSlopes(6); ExecSlopes(7); ExecSlopes(8); }
+        if (settings.SlopesSides) { ExecSlopes(9); ExecSlopes(10); ExecSlopes(11); ExecSlopes(12); }
 
         void ExecSlopes(int content)
         {
@@ -343,39 +318,37 @@ public class GridShaper
             var supportDirectionA = -probeDirectionA;
             var supportDirectionB = -probeDirectionB;
 
-            foreach (var g in bmp.Indices())
+            // Multithreaded Slope Evaluation strictly over filled blocks
+            System.Threading.Tasks.Parallel.ForEach(activeBlocks, new System.Threading.Tasks.ParallelOptions { CancellationToken = ct }, g =>
             {
-                ct.ThrowIfCancellationRequested();
-                if (blueprint[g] != 0)
-                    continue;
+                if (blueprint[g] != 0) return;
 
-                if(blueprint[g + probeDirectionA] != BlueprintMesh.NoContent || blueprint[g + probeDirectionB] != BlueprintMesh.NoContent)
+                if (blueprint[g + probeDirectionA] != BlueprintMesh.NoContent || blueprint[g + probeDirectionB] != BlueprintMesh.NoContent)
                 {
-                    continue;
+                    return;
                 }
 
                 if (settings.SlopesMustBeSupported)
                 {
-                    if(blueprint[g + supportDirectionA] != 0 || blueprint[g + supportDirectionB] != 0)
+                    if (blueprint[g + supportDirectionA] != 0 || blueprint[g + supportDirectionB] != 0)
                     {
-                        continue;
+                        return;
                     }
                 }
 
                 bmp[g] = content;
-            }
+            });
 
             if (totalSlopePasses > 0)
             {
-                executedPasses++;
-                progress?.Report((0.70 + (0.30 * ((double)executedPasses / totalSlopePasses)), "Slope Evaluation..."));
+                int currentPass = System.Threading.Interlocked.Increment(ref executedPasses);
+                progress?.Report((0.70 + (0.30 * ((double)currentPass / totalSlopePasses)), "Slope Evaluation..."));
             }
         }
 
         progress?.Report((1.0, "Complete!"));
         return blueprint;
     }
-}
 
     public class GridMesher
     {
@@ -674,129 +647,130 @@ public class GridShaper
         }
     }
 
-public static class VoxelizationKernel
-{
-    // GPU-safe math implementations
-    private static int Min(int a, int b) => a < b ? a : b;
-    private static int Max(int a, int b) => a > b ? a : b;
-    private static float Min(float a, float b) => a < b ? a : b;
-    private static float Max(float a, float b) => a > b ? a : b;
-    private static float Abs(float v) => v < 0f ? -v : v;
-    private static float Min3(float a, float b, float c) => Min(a, Min(b, c));
-    private static float Max3(float a, float b, float c) => Max(a, Max(b, c));
-    private static int Floor(float val) => val < 0f ? (int)val - 1 : (int)val;
-    private static int Ceiling(float val) => val > (int)val ? (int)val + 1 : (int)val;
-
-    public static void Voxelize(
-        Index1D index,
-        ArrayView<GpuTriangle> triangles,
-        ArrayView<int> voxelGrid,
-        Float3 gridOrigin,
-        float cellSize,
-        int gridX,
-        int gridY,
-        int gridZ)
+    public static class VoxelizationKernel
     {
-        var tri = triangles[index];
+        // GPU-safe math implementations
+        private static int Min(int a, int b) => a < b ? a : b;
+        private static int Max(int a, int b) => a > b ? a : b;
+        private static float Min(float a, float b) => a < b ? a : b;
+        private static float Max(float a, float b) => a > b ? a : b;
+        private static float Abs(float v) => v < 0f ? -v : v;
+        private static float Min3(float a, float b, float c) => Min(a, Min(b, c));
+        private static float Max3(float a, float b, float c) => Max(a, Max(b, c));
+        private static int Floor(float val) => val < 0f ? (int)val - 1 : (int)val;
+        private static int Ceiling(float val) => val > (int)val ? (int)val + 1 : (int)val;
 
-        int minX = Max(0, Floor((tri.MinBounds.X - gridOrigin.X) / cellSize));
-        int minY = Max(0, Floor((tri.MinBounds.Y - gridOrigin.Y) / cellSize));
-        int minZ = Max(0, Floor((tri.MinBounds.Z - gridOrigin.Z) / cellSize));
-
-        int maxX = Min(gridX - 1, Ceiling((tri.MaxBounds.X - gridOrigin.X) / cellSize));
-        int maxY = Min(gridY - 1, Ceiling((tri.MaxBounds.Y - gridOrigin.Y) / cellSize));
-        int maxZ = Min(gridZ - 1, Ceiling((tri.MaxBounds.Z - gridOrigin.Z) / cellSize));
-
-        // OPTIMIZATION 1: Precompute triangle edges and normal outside the loop
-        float e0X = tri.V1.X - tri.V0.X; float e0Y = tri.V1.Y - tri.V0.Y; float e0Z = tri.V1.Z - tri.V0.Z;
-        float e1X = tri.V2.X - tri.V1.X; float e1Y = tri.V2.Y - tri.V1.Y; float e1Z = tri.V2.Z - tri.V1.Z;
-        float e2X = tri.V0.X - tri.V2.X; float e2Y = tri.V0.Y - tri.V2.Y; float e2Z = tri.V0.Z - tri.V2.Z;
-
-        float normalX = e0Y * e1Z - e0Z * e1Y;
-        float normalY = e0Z * e1X - e0X * e1Z;
-        float normalZ = e0X * e1Y - e0Y * e1X;
-
-        for (int z = minZ; z <= maxZ; z++)
+        public static void Voxelize(
+            Index1D index,
+            ArrayView<GpuTriangle> triangles,
+            ArrayView<int> voxelGrid,
+            Float3 gridOrigin,
+            float cellSize,
+            int gridX,
+            int gridY,
+            int gridZ)
         {
-            for (int y = minY; y <= maxY; y++)
+            var tri = triangles[index];
+
+            int minX = Max(0, Floor((tri.MinBounds.X - gridOrigin.X) / cellSize));
+            int minY = Max(0, Floor((tri.MinBounds.Y - gridOrigin.Y) / cellSize));
+            int minZ = Max(0, Floor((tri.MinBounds.Z - gridOrigin.Z) / cellSize));
+
+            int maxX = Min(gridX - 1, Ceiling((tri.MaxBounds.X - gridOrigin.X) / cellSize));
+            int maxY = Min(gridY - 1, Ceiling((tri.MaxBounds.Y - gridOrigin.Y) / cellSize));
+            int maxZ = Min(gridZ - 1, Ceiling((tri.MaxBounds.Z - gridOrigin.Z) / cellSize));
+
+            // OPTIMIZATION 1: Precompute triangle edges and normal outside the loop
+            float e0X = tri.V1.X - tri.V0.X; float e0Y = tri.V1.Y - tri.V0.Y; float e0Z = tri.V1.Z - tri.V0.Z;
+            float e1X = tri.V2.X - tri.V1.X; float e1Y = tri.V2.Y - tri.V1.Y; float e1Z = tri.V2.Z - tri.V1.Z;
+            float e2X = tri.V0.X - tri.V2.X; float e2Y = tri.V0.Y - tri.V2.Y; float e2Z = tri.V0.Z - tri.V2.Z;
+
+            float normalX = e0Y * e1Z - e0Z * e1Y;
+            float normalY = e0Z * e1X - e0X * e1Z;
+            float normalZ = e0X * e1Y - e0Y * e1X;
+
+            for (int z = minZ; z <= maxZ; z++)
             {
-                for (int x = minX; x <= maxX; x++)
+                for (int y = minY; y <= maxY; y++)
                 {
-                    Float3 cellCenter = new Float3(
-                        gridOrigin.X + (x + 0.5f) * cellSize,
-                        gridOrigin.Y + (y + 0.5f) * cellSize,
-                        gridOrigin.Z + (z + 0.5f) * cellSize
-                    );
-
-                    // Pass precomputed values into the intersection test
-                    if (CheckTriangleBoxIntersection(tri, cellCenter, cellSize,
-                        e0X, e0Y, e0Z, e1X, e1Y, e1Z, e2X, e2Y, e2Z, normalX, normalY, normalZ))
+                    for (int x = minX; x <= maxX; x++)
                     {
-                        int flatIndex = x + (y * gridX) + (z * gridX * gridY);
+                        Float3 cellCenter = new Float3(
+                            gridOrigin.X + (x + 0.5f) * cellSize,
+                            gridOrigin.Y + (y + 0.5f) * cellSize,
+                            gridOrigin.Z + (z + 0.5f) * cellSize
+                        );
 
-                        // OPTIMIZATION 2: Cache-friendly early exit prevents memory bus locking
-                        if (voxelGrid[flatIndex] != 0)
+                        // Pass precomputed values into the intersection test
+                        if (CheckTriangleBoxIntersection(tri, cellCenter, cellSize,
+                            e0X, e0Y, e0Z, e1X, e1Y, e1Z, e2X, e2Y, e2Z, normalX, normalY, normalZ))
                         {
-                            Atomic.Exchange(ref voxelGrid[flatIndex], 0);
+                            int flatIndex = x + (y * gridX) + (z * gridX * gridY);
+
+                            // OPTIMIZATION 2: Cache-friendly early exit prevents memory bus locking
+                            if (voxelGrid[flatIndex] != 0)
+                            {
+                                Atomic.Exchange(ref voxelGrid[flatIndex], 0);
+                            }
                         }
                     }
                 }
             }
         }
-    }
 
-    private static bool CheckTriangleBoxIntersection(
-        GpuTriangle tri, Float3 boxCenter, float cellSize,
-        float e0X, float e0Y, float e0Z,
-        float e1X, float e1Y, float e1Z,
-        float e2X, float e2Y, float e2Z,
-        float normalX, float normalY, float normalZ)
-    {
-        float boxHalf = cellSize * 0.5f;
+        private static bool CheckTriangleBoxIntersection(
+            GpuTriangle tri, Float3 boxCenter, float cellSize,
+            float e0X, float e0Y, float e0Z,
+            float e1X, float e1Y, float e1Z,
+            float e2X, float e2Y, float e2Z,
+            float normalX, float normalY, float normalZ)
+        {
+            float boxHalf = cellSize * 0.5f;
 
-        // Shift triangle to local AABB coordinate space
-        float v0X = tri.V0.X - boxCenter.X; float v0Y = tri.V0.Y - boxCenter.Y; float v0Z = tri.V0.Z - boxCenter.Z;
-        float v1X = tri.V1.X - boxCenter.X; float v1Y = tri.V1.Y - boxCenter.Y; float v1Z = tri.V1.Z - boxCenter.Z;
-        float v2X = tri.V2.X - boxCenter.X; float v2Y = tri.V2.Y - boxCenter.Y; float v2Z = tri.V2.Z - boxCenter.Z;
+            // Shift triangle to local AABB coordinate space
+            float v0X = tri.V0.X - boxCenter.X; float v0Y = tri.V0.Y - boxCenter.Y; float v0Z = tri.V0.Z - boxCenter.Z;
+            float v1X = tri.V1.X - boxCenter.X; float v1Y = tri.V1.Y - boxCenter.Y; float v1Z = tri.V1.Z - boxCenter.Z;
+            float v2X = tri.V2.X - boxCenter.X; float v2Y = tri.V2.Y - boxCenter.Y; float v2Z = tri.V2.Z - boxCenter.Z;
 
-        // SAT Test 1: Box AABB bounds
-        if (Min3(v0X, v1X, v2X) > boxHalf || Max3(v0X, v1X, v2X) < -boxHalf) return false;
-        if (Min3(v0Y, v1Y, v2Y) > boxHalf || Max3(v0Y, v1Y, v2Y) < -boxHalf) return false;
-        if (Min3(v0Z, v1Z, v2Z) > boxHalf || Max3(v0Z, v1Z, v2Z) < -boxHalf) return false;
+            // SAT Test 1: Box AABB bounds
+            if (Min3(v0X, v1X, v2X) > boxHalf || Max3(v0X, v1X, v2X) < -boxHalf) return false;
+            if (Min3(v0Y, v1Y, v2Y) > boxHalf || Max3(v0Y, v1Y, v2Y) < -boxHalf) return false;
+            if (Min3(v0Z, v1Z, v2Z) > boxHalf || Max3(v0Z, v1Z, v2Z) < -boxHalf) return false;
 
-        // SAT Test 2: Triangle Plane vs Box Overlap
-        float d = -(normalX * v0X + normalY * v0Y + normalZ * v0Z);
+            // SAT Test 2: Triangle Plane vs Box Overlap
+            float d = -(normalX * v0X + normalY * v0Y + normalZ * v0Z);
 
-        float vminX = normalX > 0f ? -boxHalf : boxHalf; float vmaxX = normalX > 0f ? boxHalf : -boxHalf;
-        float vminY = normalY > 0f ? -boxHalf : boxHalf; float vmaxY = normalY > 0f ? boxHalf : -boxHalf;
-        float vminZ = normalZ > 0f ? -boxHalf : boxHalf; float vmaxZ = normalZ > 0f ? boxHalf : -boxHalf;
+            float vminX = normalX > 0f ? -boxHalf : boxHalf; float vmaxX = normalX > 0f ? boxHalf : -boxHalf;
+            float vminY = normalY > 0f ? -boxHalf : boxHalf; float vmaxY = normalY > 0f ? boxHalf : -boxHalf;
+            float vminZ = normalZ > 0f ? -boxHalf : boxHalf; float vmaxZ = normalZ > 0f ? boxHalf : -boxHalf;
 
-        if ((normalX * vminX + normalY * vminY + normalZ * vminZ) + d > 0f) return false;
-        if ((normalX * vmaxX + normalY * vmaxY + normalZ * vmaxZ) + d < 0f) return false;
+            if ((normalX * vminX + normalY * vminY + normalZ * vminZ) + d > 0f) return false;
+            if ((normalX * vmaxX + normalY * vmaxY + normalZ * vmaxZ) + d < 0f) return false;
 
-        // SAT Test 3: Edge Cross Products
-        if (!AxisTest(e0Z, -e0Y, v0Y, v0Z, v2Y, v2Z, boxHalf)) return false;
-        if (!AxisTest(e1Z, -e1Y, v1Y, v1Z, v0Y, v0Z, boxHalf)) return false;
-        if (!AxisTest(e2Z, -e2Y, v2Y, v2Z, v1Y, v1Z, boxHalf)) return false;
+            // SAT Test 3: Edge Cross Products
+            if (!AxisTest(e0Z, -e0Y, v0Y, v0Z, v2Y, v2Z, boxHalf)) return false;
+            if (!AxisTest(e1Z, -e1Y, v1Y, v1Z, v0Y, v0Z, boxHalf)) return false;
+            if (!AxisTest(e2Z, -e2Y, v2Y, v2Z, v1Y, v1Z, boxHalf)) return false;
 
-        if (!AxisTest(-e0Z, e0X, v0X, v0Z, v2X, v2Z, boxHalf)) return false;
-        if (!AxisTest(-e1Z, e1X, v1X, v1Z, v0X, v0Z, boxHalf)) return false;
-        if (!AxisTest(-e2Z, e2X, v2X, v2Z, v1X, v1Z, boxHalf)) return false;
+            if (!AxisTest(-e0Z, e0X, v0X, v0Z, v2X, v2Z, boxHalf)) return false;
+            if (!AxisTest(-e1Z, e1X, v1X, v1Z, v0X, v0Z, boxHalf)) return false;
+            if (!AxisTest(-e2Z, e2X, v2X, v2Z, v1X, v1Z, boxHalf)) return false;
 
-        if (!AxisTest(e0Y, -e0X, v0X, v0Y, v2X, v2Y, boxHalf)) return false;
-        if (!AxisTest(e1Y, -e1X, v1X, v1Y, v0X, v0Y, boxHalf)) return false;
-        if (!AxisTest(e2Y, -e2X, v2X, v2Y, v1X, v1Y, boxHalf)) return false;
+            if (!AxisTest(e0Y, -e0X, v0X, v0Y, v2X, v2Y, boxHalf)) return false;
+            if (!AxisTest(e1Y, -e1X, v1X, v1Y, v0X, v0Y, boxHalf)) return false;
+            if (!AxisTest(e2Y, -e2X, v2X, v2Y, v1X, v1Y, boxHalf)) return false;
 
-        return true;
-    }
+            return true;
+        }
 
-    private static bool AxisTest(float a, float b, float fa, float fb, float va, float vb, float boxHalf)
-    {
-        float p0 = a * fa + b * fb;
-        float p2 = a * va + b * vb;
-        float min = Min(p0, p2);
-        float max = Max(p0, p2);
-        float rad = (Abs(a) + Abs(b)) * boxHalf;
-        return !(min > rad || max < -rad);
+        private static bool AxisTest(float a, float b, float fa, float fb, float va, float vb, float boxHalf)
+        {
+            float p0 = a * fa + b * fb;
+            float p2 = a * va + b * vb;
+            float min = Min(p0, p2);
+            float max = Max(p0, p2);
+            float rad = (Abs(a) + Abs(b)) * boxHalf;
+            return !(min > rad || max < -rad);
+        }
     }
 }

--- a/Algorithms/GridShaper.cs
+++ b/Algorithms/GridShaper.cs
@@ -1,14 +1,36 @@
 ﻿using Assimp;
 using g4;
+using ILGPU;
+using ILGPU.Runtime;
+using PropertyTools.DataAnnotations;
+using SpaceEditor.Algorithms;
 using SpaceEditor.Rocks;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 using System.Text;
-using PropertyTools.DataAnnotations;
 
 namespace SpaceEditor.Algorithms;
+
+// Unmanaged, SIMD-free representation of a 3D vector for ILGPU
+public struct Float3
+{
+    public float X, Y, Z;
+    public Float3(float x, float y, float z) { X = x; Y = y; Z = z; }
+}
+
+// Unmanaged representation of a triangle for the GPU
+public struct GpuTriangle
+{
+    public Float3 V0;
+    public Float3 V1;
+    public Float3 V2;
+    public Float3 MinBounds;
+    public Float3 MaxBounds;
+}
 
 public class GridShaper
 {
@@ -32,7 +54,7 @@ public class GridShaper
     {
         public bool SlopesUpper { get; set; } = true;
         public bool SlopesLower { get; set; } = true;
-        public bool SlopesSides { get; set; } = true; 
+        public bool SlopesSides { get; set; } = true;
         public bool SlopesMustBeSupported { get; set; } = false;
 
         [ItemsSourceProperty(nameof(BlockSizeValues))]
@@ -47,7 +69,7 @@ public class GridShaper
         ];
     }
 
-    public BlueprintMesh Generate(GeneratorSettings settings, CancellationToken ct)
+    public BlueprintMesh Generate(GeneratorSettings settings, CancellationToken ct, IProgress<(double, string)> progress = null)
     {
         var blockSize = settings.BlockSize switch
         {
@@ -58,19 +80,98 @@ public class GridShaper
         var minimalBounds = this.Tree.Bounds;
         minimalBounds.Min -= blockSize;
         minimalBounds.Max += blockSize;
-        
-        var boundingBox = new AxisAlignedBox3d(new Vector3d(0), blockSize / 2);
+
+        var boundingBox = new g4.AxisAlignedBox3d(new g4.Vector3d(0), blockSize / 2);
         while (boundingBox.Contains(minimalBounds) == false)
         {
-            //TODO: Fix block offset
             boundingBox.Scale(2, 2, 2);
         }
 
-        var cellCount = (int) Math.Ceiling(boundingBox.MaxDim / blockSize);
+        var cellCount = (int)Math.Ceiling(boundingBox.MaxDim / blockSize);
         var indexer = new ShiftGridIndexer3(boundingBox.Min, blockSize);
 
+        // Initialize ILGPU Context
+        using var context = Context.CreateDefault();
+        using var accelerator = context.GetPreferredDevice(preferCPU: false).CreateAccelerator(context);
+
+        // Prepare Triangle Data
+        int triangleCount = this.Mesh.TriangleCount;
+        var flatTriangles = new GpuTriangle[triangleCount];
+        int tIndex = 0;
+
+        // PHASE 1: Triangles (0% - 10%)
+        foreach (var triangle in this.Mesh.EnumerateTriangles())
+        {
+            ct.ThrowIfCancellationRequested();
+            // Report progress periodically to avoid UI thread spam
+            if (tIndex % 5000 == 0) progress?.Report((0.1 * ((double)tIndex / triangleCount), "Mesh Flattening..."));
+
+            var box = triangle.ToBox();
+            flatTriangles[tIndex++] = new GpuTriangle
+            {
+                V0 = new Float3((float)triangle.V0.x, (float)triangle.V0.y, (float)triangle.V0.z),
+                V1 = new Float3((float)triangle.V1.x, (float)triangle.V1.y, (float)triangle.V1.z),
+                V2 = new Float3((float)triangle.V2.x, (float)triangle.V2.y, (float)triangle.V2.z),
+                MinBounds = new Float3((float)box.Min.x, (float)box.Min.y, (float)box.Min.z),
+                MaxBounds = new Float3((float)box.Max.x, (float)box.Max.y, (float)box.Max.z)
+            };
+        }
+
+        // Allocate GPU Memory
+        using var deviceTriangles = accelerator.Allocate1D(flatTriangles);
+
+        // Flat 1D representation of the 3D voxel grid
+        int totalCells = cellCount * cellCount * cellCount;
+        int[] initialGrid = new int[totalCells];
+        Array.Fill(initialGrid, BlueprintMesh.NoContent);
+        using var deviceGrid = accelerator.Allocate1D(initialGrid);
+
+        // Load and compile kernel
+        var voxelizeKernel = accelerator.LoadAutoGroupedStreamKernel<
+            Index1D, ArrayView<GpuTriangle>, ArrayView<int>, Float3, float, int, int, int>(
+            VoxelizationKernel.Voxelize);
+
+        Float3 origin = new Float3((float)boundingBox.Min.x, (float)boundingBox.Min.y, (float)boundingBox.Min.z);
+
+        // Dispatch execution to the GPU
+        voxelizeKernel(
+            deviceTriangles.IntExtent,
+            deviceTriangles.View,
+            deviceGrid.View,
+            origin,
+            blockSize,
+            cellCount,
+            cellCount,
+            cellCount
+        );
+
+        // PHASE 2: Voxelization (Jump to 40% after sync)
+        accelerator.Synchronize();
+        progress?.Report((0.40, "Voxelization..."));
+        var flatResults = deviceGrid.GetAsArray1D();
+
+        // Reconstruct the internal BlueprintMesh data structure
         var bmp = new DenseGrid3i(cellCount, cellCount, cellCount, BlueprintMesh.NoContent);
-        
+
+        // PHASE 3: Grid Reconstruction (40% - 70%)
+        for (int z = 0; z < cellCount; z++)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (z % 10 == 0) progress?.Report((0.40 + (0.30 * ((double)z / cellCount)), "Grid Reconstruction..."));
+
+            for (int y = 0; y < cellCount; y++)
+            {
+                for (int x = 0; x < cellCount; x++)
+                {
+                    int flatIdx = x + (y * cellCount) + (z * cellCount * cellCount);
+                    if (flatResults[flatIdx] == 0)
+                    {
+                        bmp[new g4.Vector3i(x, y, z)] = 0;
+                    }
+                }
+            }
+        }
+
         var blueprint = new BlueprintMesh();
         blueprint.Blocks = bmp;
         blueprint.Coords = indexer;
@@ -79,19 +180,11 @@ public class GridShaper
             BlockSizes.TwoPointFive => ShapeDB.LargeShapes,
             BlockSizes.HalfMeter => ShapeDB.MidShapes
         };
-        
-        foreach (var triangle in this.Mesh.EnumerateTriangles())
-        {
-            var triBox = triangle.ToBox();
-            foreach (var cell in Enumerators.BoxRange(triBox, indexer))
-            {
-                var cellBox = indexer.ToBox(cell);
-                if (cellBox.IntersectWithTriangle(triangle) != IntersectResult.NoIntersection)
-                {
-                    bmp[cell] = 0; //Cube
-                }
-            }
-        }
+
+        // PHASE 4: Slope Generation (70% - 100%)
+        progress?.Report((0.70, "Slope Evaluation...")); 
+        int totalSlopePasses = (settings.SlopesUpper ? 4 : 0) + (settings.SlopesLower ? 4 : 0) + (settings.SlopesSides ? 4 : 0);
+        int executedPasses = 0;
 
         if (settings.SlopesUpper)
         {
@@ -127,26 +220,19 @@ public class GridShaper
 
             foreach (var g in bmp.Indices())
             {
-                if (blueprint[g] != 0)
-                    continue;
+                ct.ThrowIfCancellationRequested();
 
-                if
-                (
-                    blueprint[g + probeDirectionA] != BlueprintMesh.NoContent ||
-                    blueprint[g + probeDirectionB] != BlueprintMesh.NoContent
-                )
+                if (blueprint[g] != 0) continue;
+
+                if(blueprint[g + probeDirectionA] != BlueprintMesh.NoContent ||blueprint[g + probeDirectionB] != BlueprintMesh.NoContent)
                 {
                     continue;
                 }
 
                 if (settings.SlopesMustBeSupported)
                 {
-                    if
-                    (
-                        //TODO: Should use face check, something symmetric
-                        blueprint[g + supportDirectionA] != 0 ||
-                        blueprint[g + supportDirectionB] != 0
-                    )
+                    ct.ThrowIfCancellationRequested();
+                    if(blueprint[g + supportDirectionA] != 0 || blueprint[g + supportDirectionB] != 0)
                     {
                         continue;
                     }
@@ -156,303 +242,549 @@ public class GridShaper
             }
         }
 
+        // Report progress after each directional pass completes
+        if (totalSlopePasses > 0)
+        {
+            executedPasses++;
+            progress?.Report((0.70 + (0.30 * ((double)executedPasses / totalSlopePasses)), "Slope Evaluation..."));
+        }
+
+        progress?.Report((1.0, "Complete!"));
+        return blueprint;
+    }
+
+    //Old, CPU based rendering. Kept here as a legacy option, in case using the GPU is not feasible for some reason. It is significantly slower than the GPU version, especially for large meshes.
+    public BlueprintMesh GenerateCpu(GeneratorSettings settings, CancellationToken ct, IProgress<(double, string)> progress = null)
+    {
+        var blockSize = settings.BlockSize switch
+        {
+            BlockSizes.TwoPointFive => ShapeDB.LargeBlockSize,
+            BlockSizes.HalfMeter => ShapeDB.MidBlockSize
+        };
+
+        var minimalBounds = this.Tree.Bounds;
+        minimalBounds.Min -= blockSize;
+        minimalBounds.Max += blockSize;
+        
+        var boundingBox = new AxisAlignedBox3d(new Vector3d(0), blockSize / 2);
+        while (boundingBox.Contains(minimalBounds) == false)
+        {
+            boundingBox.Scale(2, 2, 2);
+        }
+
+        var cellCount = (int) Math.Ceiling(boundingBox.MaxDim / blockSize);
+        var indexer = new ShiftGridIndexer3(boundingBox.Min, blockSize);
+
+        var bmp = new DenseGrid3i(cellCount, cellCount, cellCount, BlueprintMesh.NoContent);
+        
+        var blueprint = new BlueprintMesh();
+        blueprint.Blocks = bmp;
+        blueprint.Coords = indexer;
+        blueprint.Shapes = settings.BlockSize switch
+        {
+            BlockSizes.TwoPointFive => ShapeDB.LargeShapes,
+            BlockSizes.HalfMeter => ShapeDB.MidShapes
+        };
+
+        int triangleCount = this.Mesh.TriangleCount;
+        int tIndex = 0;
+
+        foreach (var triangle in this.Mesh.EnumerateTriangles())
+        {
+            ct.ThrowIfCancellationRequested();
+            if (tIndex % 1000 == 0) progress?.Report((0.7 * ((double)tIndex / triangleCount), "Triangle Evaluation..."));
+            tIndex++;
+
+            var triBox = triangle.ToBox();
+            foreach (var cell in Enumerators.BoxRange(triBox, indexer))
+            {
+                var cellBox = indexer.ToBox(cell);
+                if (cellBox.IntersectWithTriangle(triangle) != IntersectResult.NoIntersection)
+                {
+                    bmp[cell] = 0; //Cube
+                }
+            }
+        }
+
+        progress?.Report((0.70, "Dispatch & Execution..."));
+        int totalSlopePasses = (settings.SlopesUpper ? 4 : 0) + (settings.SlopesLower ? 4 : 0) + (settings.SlopesSides ? 4 : 0);
+        int executedPasses = 0;
+
+        if (settings.SlopesUpper)
+        {
+            ExecSlopes(1);
+            ExecSlopes(2);
+            ExecSlopes(3);
+            ExecSlopes(4);
+        }
+
+        if (settings.SlopesLower)
+        {
+            ExecSlopes(5);
+            ExecSlopes(6);
+            ExecSlopes(7);
+            ExecSlopes(8);
+        }
+
+        if (settings.SlopesSides)
+        {
+            ExecSlopes(9);
+            ExecSlopes(10);
+            ExecSlopes(11);
+            ExecSlopes(12);
+        }
+
+        void ExecSlopes(int content)
+        {
+            var shapeInfo = blueprint.Shapes[content];
+            var probeDirectionA = -Base6Directions.Vectors[shapeInfo.Forward];
+            var probeDirectionB = Base6Directions.Vectors[shapeInfo.Up];
+            var supportDirectionA = -probeDirectionA;
+            var supportDirectionB = -probeDirectionB;
+
+            foreach (var g in bmp.Indices())
+            {
+                ct.ThrowIfCancellationRequested();
+                if (blueprint[g] != 0)
+                    continue;
+
+                if(blueprint[g + probeDirectionA] != BlueprintMesh.NoContent || blueprint[g + probeDirectionB] != BlueprintMesh.NoContent)
+                {
+                    continue;
+                }
+
+                if (settings.SlopesMustBeSupported)
+                {
+                    if(blueprint[g + supportDirectionA] != 0 || blueprint[g + supportDirectionB] != 0)
+                    {
+                        continue;
+                    }
+                }
+
+                bmp[g] = content;
+            }
+
+            if (totalSlopePasses > 0)
+            {
+                executedPasses++;
+                progress?.Report((0.70 + (0.30 * ((double)executedPasses / totalSlopePasses)), "Slope Evaluation..."));
+            }
+        }
+
+        progress?.Report((1.0, "Complete!"));
         return blueprint;
     }
 }
 
-public class GridMesher
-{
-    public static DMesh3 Mesh(BlueprintMesh blueprint)
+    public class GridMesher
     {
-        var grid = blueprint.Blocks;
-        
-        var cubes = new Bitmap3(new(grid.ni, grid.nj, grid.nk));
-        foreach(var g in grid.Indices())
+        public static DMesh3 Mesh(BlueprintMesh blueprint)
         {
-            cubes[g] = grid[g] == 0;
-        }
+            var grid = blueprint.Blocks;
 
-        var slopeMesh = new DMesh3();
-        foreach (var g in grid.Indices())
-        {
-            if (cubes[g])
-                continue;
-
-            var shapeId = grid[g];
-            if (shapeId == BlueprintMesh.NoContent)
-                continue;
-
-            var shapeInfo = blueprint.Shapes[shapeId];
-
-            slopeMesh.AppendMesh
-            (
-                shapeInfo.Shape,
-                MathRocks.ForwardUpTranslate
-                (
-                    shapeInfo.Forward,
-                    shapeInfo.Up,
-                    (Vector3f) blueprint.Coords.ToBox(g).Center
-                )
-            );
-        }
-        
-        var cubesSurfaceGenerator = new VoxelSurfaceGenerator();
-        cubesSurfaceGenerator.Voxels = cubes;
-        cubesSurfaceGenerator.Generate();
-        
-        var cubesMesh = cubesSurfaceGenerator.Meshes[0];
-        MeshTransforms.Scale(cubesMesh, blueprint.Coords.CellSize);
-
-        // Voxel generator generates around UnitZeroCentered, while indexer rounds down to corner
-        var correctionOffset = blueprint.Coords.CellSize / 2;
-        MeshTransforms.Translate(cubesMesh, blueprint.Coords.Origin + correctionOffset);
-
-
-        var finalMesh = cubesMesh;
-        finalMesh.AppendMesh(slopeMesh);
-
-        return finalMesh;
-    }
-}
-
-public class ShapeDB
-{
-    public const float LargeBlockSize = 2.5f;
-    public const float MidBlockSize = 0.5f;
-    public const float SmallBlockSize = 0.25f;
-
-    public record ShapeInfo
-    {
-        public DMesh3 Shape;
-        public string Prefab;
-
-        public int Forward = Base6Directions.Forward;
-        public int Up = Base6Directions.Up;
-    }
-
-    public ShapeInfo[] Shapes { get; }
-    public ShapeInfo this[int index] => this.Shapes[index];
-
-    public ShapeDB(params ShapeInfo[] shapes)
-    {
-        this.Shapes = shapes;
-    }
-
-    public static ShapeDB LargeShapes = new
-    (
-        // Cube
-        CubicShape("2eacbbf2-d8fb-4a78-91dc-7b492517ef97", x => x.AppendBox(Dims(LargeBlockSize))),
-
-        // Slopes
-        SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Left, Base6Directions.Up),
-        SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Right, Base6Directions.Up),
-        SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Forward, Base6Directions.Up),
-        SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Backward, Base6Directions.Up),
-
-        SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Left, Base6Directions.Down),
-        SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Right, Base6Directions.Down),
-        SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Forward, Base6Directions.Down),
-        SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Backward, Base6Directions.Down),
-
-        SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Forward, Base6Directions.Left),
-        SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Left, Base6Directions.Backward),
-        SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Backward, Base6Directions.Right),
-        SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Right, Base6Directions.Forward)
-    );
-
-    public static ShapeDB MidShapes = new
-    (
-        // Cube
-        CubicShape("632d7385-12b9-47a6-802a-a610d0cbd1e0", x => x.AppendBox(Dims(MidBlockSize))),
-
-        // Slopes
-        SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Left, Base6Directions.Up),
-        SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Right, Base6Directions.Up),
-        SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Forward, Base6Directions.Up),
-        SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Backward, Base6Directions.Up),
-
-        SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Left, Base6Directions.Down),
-        SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Right, Base6Directions.Down),
-        SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Forward, Base6Directions.Down),
-        SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Backward, Base6Directions.Down),
-
-        SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Forward, Base6Directions.Left),
-        SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Left, Base6Directions.Backward),
-        SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Backward, Base6Directions.Right),
-        SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Right, Base6Directions.Forward)
-    );
-
-    private static ShapeInfo SlopeShape(string prefab, float size, int forward, int up)
-    {
-        var info = CubicShape
-        (
-            prefab,
-            x =>
+            var cubes = new Bitmap3(new(grid.ni, grid.nj, grid.nk));
+            foreach (var g in grid.Indices())
             {
-                x.AppendSlope
+                cubes[g] = grid[g] == 0;
+            }
+
+            var slopeMesh = new DMesh3();
+            foreach (var g in grid.Indices())
+            {
+                if (cubes[g])
+                    continue;
+
+                var shapeId = grid[g];
+                if (shapeId == BlueprintMesh.NoContent)
+                    continue;
+
+                var shapeInfo = blueprint.Shapes[shapeId];
+
+                slopeMesh.AppendMesh
                 (
-                    Dims(size),
-                    Base6Directions.Vectors[forward],
-                    -Base6Directions.Vectors[up]
+                    shapeInfo.Shape,
+                    MathRocks.ForwardUpTranslate
+                    (
+                        shapeInfo.Forward,
+                        shapeInfo.Up,
+                        (Vector3f)blueprint.Coords.ToBox(g).Center
+                    )
                 );
             }
+
+            var cubesSurfaceGenerator = new VoxelSurfaceGenerator();
+            cubesSurfaceGenerator.Voxels = cubes;
+            cubesSurfaceGenerator.Generate();
+
+            var cubesMesh = cubesSurfaceGenerator.Meshes[0];
+            MeshTransforms.Scale(cubesMesh, blueprint.Coords.CellSize);
+
+            // Voxel generator generates around UnitZeroCentered, while indexer rounds down to corner
+            var correctionOffset = blueprint.Coords.CellSize / 2;
+            MeshTransforms.Translate(cubesMesh, blueprint.Coords.Origin + correctionOffset);
+
+
+            var finalMesh = cubesMesh;
+            finalMesh.AppendMesh(slopeMesh);
+
+            return finalMesh;
+        }
+    }
+
+    public class ShapeDB
+    {
+        public const float LargeBlockSize = 2.5f;
+        public const float MidBlockSize = 0.5f;
+        public const float SmallBlockSize = 0.25f;
+
+        public record ShapeInfo
+        {
+            public DMesh3 Shape;
+            public string Prefab;
+
+            public int Forward = Base6Directions.Forward;
+            public int Up = Base6Directions.Up;
+        }
+
+        public ShapeInfo[] Shapes { get; }
+        public ShapeInfo this[int index] => this.Shapes[index];
+
+        public ShapeDB(params ShapeInfo[] shapes)
+        {
+            this.Shapes = shapes;
+        }
+
+        public static ShapeDB LargeShapes = new
+        (
+            // Cube
+            CubicShape("2eacbbf2-d8fb-4a78-91dc-7b492517ef97", x => x.AppendBox(Dims(LargeBlockSize))),
+
+            // Slopes
+            SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Left, Base6Directions.Up),
+            SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Right, Base6Directions.Up),
+            SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Forward, Base6Directions.Up),
+            SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Backward, Base6Directions.Up),
+
+            SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Left, Base6Directions.Down),
+            SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Right, Base6Directions.Down),
+            SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Forward, Base6Directions.Down),
+            SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Backward, Base6Directions.Down),
+
+            SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Forward, Base6Directions.Left),
+            SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Left, Base6Directions.Backward),
+            SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Backward, Base6Directions.Right),
+            SlopeShape("f9efcc6c-6c76-4762-bbf0-6013ec969539", LargeBlockSize, Base6Directions.Right, Base6Directions.Forward)
         );
 
-        info.Up = up;
-        info.Forward = forward;
-        return info;
-    }
+        public static ShapeDB MidShapes = new
+        (
+            // Cube
+            CubicShape("632d7385-12b9-47a6-802a-a610d0cbd1e0", x => x.AppendBox(Dims(MidBlockSize))),
 
-    private static ShapeInfo CubicShape(string prefab, Action<DMesh3> shape)
-    {
-        return new()
+            // Slopes
+            SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Left, Base6Directions.Up),
+            SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Right, Base6Directions.Up),
+            SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Forward, Base6Directions.Up),
+            SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Backward, Base6Directions.Up),
+
+            SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Left, Base6Directions.Down),
+            SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Right, Base6Directions.Down),
+            SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Forward, Base6Directions.Down),
+            SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Backward, Base6Directions.Down),
+
+            SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Forward, Base6Directions.Left),
+            SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Left, Base6Directions.Backward),
+            SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Backward, Base6Directions.Right),
+            SlopeShape("69902790-3e2d-43d2-81e4-1c0b42bc7461", MidBlockSize, Base6Directions.Right, Base6Directions.Forward)
+        );
+
+        private static ShapeInfo SlopeShape(string prefab, float size, int forward, int up)
         {
-            Prefab = prefab,
-            Shape = MakeShape(shape)
-        };
-    }
+            var info = CubicShape
+            (
+                prefab,
+                x =>
+                {
+                    x.AppendSlope
+                    (
+                        Dims(size),
+                        Base6Directions.Vectors[forward],
+                        -Base6Directions.Vectors[up]
+                    );
+                }
+            );
 
-    private static AxisAlignedBox3f Dims(float size)
-    {
-        return new(Vector3f.Zero, size / 2);
-    }
+            info.Up = up;
+            info.Forward = forward;
+            return info;
+        }
 
-    private static DMesh3 MakeShape(Action<DMesh3> factory)
-    {
-        var mesh = new DMesh3();
-        factory(mesh);
-        return mesh;
-    }
-}
-
-public class BlueprintMesh
-{
-    public const int NoContent = int.MaxValue;
-
-    public DenseGrid3i Blocks;
-    public ShiftGridIndexer3 Coords;
-    public ShapeDB Shapes;
-
-    public int this[Vector3i index]
-    {
-        get
+        private static ShapeInfo CubicShape(string prefab, Action<DMesh3> shape)
         {
-            if (this.Blocks.IsValidIndex(index) == false)
-                return NoContent;
+            return new()
+            {
+                Prefab = prefab,
+                Shape = MakeShape(shape)
+            };
+        }
 
-            return this.Blocks[index];
+        private static AxisAlignedBox3f Dims(float size)
+        {
+            return new(Vector3f.Zero, size / 2);
+        }
+
+        private static DMesh3 MakeShape(Action<DMesh3> factory)
+        {
+            var mesh = new DMesh3();
+            factory(mesh);
+            return mesh;
         }
     }
-}
 
-public class BlueprintWriter
-{
-    public required string WriteFolder { get; set; }
-
-    public void Write(BlueprintMesh blueprint, string name)
+    public class BlueprintMesh
     {
-        var sb = new StringBuilder();
-        Generate(blueprint, sb);
-        File.WriteAllText(Path.Combine(this.WriteFolder, $"{name}.txt"), sb.ToString());
+        public const int NoContent = int.MaxValue;
+
+        public DenseGrid3i Blocks;
+        public ShiftGridIndexer3 Coords;
+        public ShapeDB Shapes;
+
+        public int this[Vector3i index]
+        {
+            get
+            {
+                if (this.Blocks.IsValidIndex(index) == false)
+                    return NoContent;
+
+                return this.Blocks[index];
+            }
+        }
     }
 
-    public void Generate(BlueprintMesh blueprint, StringBuilder sb)
+    public class BlueprintWriter
     {
-        //Prefab|PositionX|PositionY|PositionZ|ColorHUE|ColorSATURATION|ColorVALUE|OrientationFORWARD|OrientationUP|Integrity
-        var blockGrid = blueprint.Blocks;
-        foreach (var g in blockGrid.Indices())
-        {
-            var content = blockGrid[g];
-            if (content == BlueprintMesh.NoContent)
-                continue;
+        public required string WriteFolder { get; set; }
 
-            if (content < 0)
+        public void Write(BlueprintMesh blueprint, string name)
+        {
+            var sb = new StringBuilder();
+            Generate(blueprint, sb);
+            File.WriteAllText(Path.Combine(this.WriteFolder, $"{name}.txt"), sb.ToString());
+        }
+
+        public void Generate(BlueprintMesh blueprint, StringBuilder sb)
+        {
+            //Prefab|PositionX|PositionY|PositionZ|ColorHUE|ColorSATURATION|ColorVALUE|OrientationFORWARD|OrientationUP|Integrity
+            var blockGrid = blueprint.Blocks;
+            foreach (var g in blockGrid.Indices())
             {
-                throw new NotImplementedException("Shape lists will go here");
+                var content = blockGrid[g];
+                if (content == BlueprintMesh.NoContent)
+                    continue;
+
+                if (content < 0)
+                {
+                    throw new NotImplementedException("Shape lists will go here");
+                }
+
+                var block = blueprint.Shapes[content];
+                sb.Append(block.Prefab);
+                sb.Append('|');
+
+                var forwardAxis = block.Forward;
+                var upAxis = block.Up;
+
+                var cube = blueprint.Coords.ToBox(g);
+                var gridPosition = ToInt(cube.Center / ShapeDB.SmallBlockSize);
+                gridPosition += PositionOffset
+                (
+                    //TODO:
+                    blueprint.Shapes == ShapeDB.LargeShapes ?
+                        new AxisAlignedBox3i(new Vector3i(-4, -4, -4), new Vector3i(5, 5, 5)) :
+                        new AxisAlignedBox3i(new Vector3i(0, 0, 0), new Vector3i(1, 1, 1)),
+                    forwardAxis,
+                    upAxis
+                );
+
+
+                sb.Append(gridPosition.x);
+                sb.Append('|');
+                sb.Append(gridPosition.y);
+                sb.Append('|');
+                sb.Append(gridPosition.z);
+                sb.Append('|');
+
+                sb.Append(0);
+                sb.Append('|');
+                sb.Append(0);
+                sb.Append('|');
+                sb.Append(0.25);
+                sb.Append('|');
+
+                sb.Append(forwardAxis);
+                sb.Append('|');
+                sb.Append(upAxis);
+                sb.Append('|');
+
+                sb.Append(1);
+                sb.Append('|');
+
+                sb.AppendLine();
             }
 
-            var block = blueprint.Shapes[content];
-            sb.Append(block.Prefab);
-            sb.Append('|');
-
-            var forwardAxis = block.Forward;
-            var upAxis = block.Up;
-
-            var cube = blueprint.Coords.ToBox(g);
-            var gridPosition = ToInt(cube.Center / ShapeDB.SmallBlockSize);
-            gridPosition += PositionOffset
-            (
-                //TODO:
-                blueprint.Shapes == ShapeDB.LargeShapes ?
-                    new AxisAlignedBox3i(new Vector3i(-4, -4, -4), new Vector3i(5, 5, 5)) : 
-                    new AxisAlignedBox3i(new Vector3i(0, 0, 0), new Vector3i(1, 1, 1)),
-                forwardAxis,
-                upAxis
-            );
-
-
-            sb.Append(gridPosition.x);
-            sb.Append('|');
-            sb.Append(gridPosition.y);
-            sb.Append('|');
-            sb.Append(gridPosition.z);
-            sb.Append('|');
-
-            sb.Append(0);
-            sb.Append('|');
-            sb.Append(0);
-            sb.Append('|');
-            sb.Append(0.25);
-            sb.Append('|');
-
-            sb.Append(forwardAxis);
-            sb.Append('|');
-            sb.Append(upAxis);
-            sb.Append('|');
-
-            sb.Append(1);
-            sb.Append('|');
-
-            sb.AppendLine();
-        }
-
-        Vector3i PositionOffset(AxisAlignedBox3i blockSize, int blockForward, int blockRight)
-        {
-            var baseRight = Base6Directions.Vectors[blockRight];
-            var baseForward = -Base6Directions.Vectors[blockForward];
-            return BlockOffset
-            (
-                blockSize,
-                new Matrix3f
+            Vector3i PositionOffset(AxisAlignedBox3i blockSize, int blockForward, int blockRight)
+            {
+                var baseRight = Base6Directions.Vectors[blockRight];
+                var baseForward = -Base6Directions.Vectors[blockForward];
+                return BlockOffset
                 (
-                    (Vector3f) baseRight.Cross(baseForward),
-                    (Vector3f) baseRight,
-                    (Vector3f) baseForward,
-                    bRows: false
-                )
-            );
-        }
+                    blockSize,
+                    new Matrix3f
+                    (
+                        (Vector3f)baseRight.Cross(baseForward),
+                        (Vector3f)baseRight,
+                        (Vector3f)baseForward,
+                        bRows: false
+                    )
+                );
+            }
 
-        static Vector3i BlockOffset(AxisAlignedBox3i blockSize, Matrix3f blockOrientation)
+            static Vector3i BlockOffset(AxisAlignedBox3i blockSize, Matrix3f blockOrientation)
+            {
+                var offsetNegative = (Vector3f)blockSize.Min;
+                var offsetPositive = (Vector3f)blockSize.Max;
+
+                var a = ToInt(blockOrientation.Multiply(ref offsetNegative));
+                var b = ToInt(blockOrientation.Multiply(ref offsetPositive));
+
+                var minI = new Vector3i(Math.Min(a.x, b.x), Math.Min(a.y, b.y), Math.Min(a.z, b.z));
+                return blockSize.Min - minI;
+            }
+
+            static Vector3i ToInt(Vector3d vec)
+            {
+                return new
+                (
+                    (int)Math.Round(vec.x),
+                    (int)Math.Round(vec.y),
+                    (int)Math.Round(vec.z)
+                );
+            }
+        }
+    }
+
+
+public static class VoxelizationKernel
+{
+    // GPU-safe math implementations must reside inside this class
+    private static int Min(int a, int b) => a < b ? a : b;
+    private static int Max(int a, int b) => a > b ? a : b;
+    private static float Min(float a, float b) => a < b ? a : b;
+    private static float Max(float a, float b) => a > b ? a : b;
+    private static float Abs(float v) => v < 0f ? -v : v;
+    private static float Min3(float a, float b, float c) => Min(a, Min(b, c));
+    private static float Max3(float a, float b, float c) => Max(a, Max(b, c));
+    private static int Floor(float val) => val < 0f ? (int)val - 1 : (int)val;
+    private static int Ceiling(float val) => val > (int)val ? (int)val + 1 : (int)val;
+
+    public static void Voxelize(
+        Index1D index,
+        ArrayView<GpuTriangle> triangles,
+        ArrayView<int> voxelGrid,
+        Float3 gridOrigin,
+        float cellSize,
+        int gridX,
+        int gridY,
+        int gridZ)
+    {
+        var tri = triangles[index];
+
+        int minX = Max(0, Floor((tri.MinBounds.X - gridOrigin.X) / cellSize));
+        int minY = Max(0, Floor((tri.MinBounds.Y - gridOrigin.Y) / cellSize));
+        int minZ = Max(0, Floor((tri.MinBounds.Z - gridOrigin.Z) / cellSize));
+
+        int maxX = Min(gridX - 1, Ceiling((tri.MaxBounds.X - gridOrigin.X) / cellSize));
+        int maxY = Min(gridY - 1, Ceiling((tri.MaxBounds.Y - gridOrigin.Y) / cellSize));
+        int maxZ = Min(gridZ - 1, Ceiling((tri.MaxBounds.Z - gridOrigin.Z) / cellSize));
+
+        for (int z = minZ; z <= maxZ; z++)
         {
-            var offsetNegative = (Vector3f) blockSize.Min;
-            var offsetPositive = (Vector3f) blockSize.Max;
+            for (int y = minY; y <= maxY; y++)
+            {
+                for (int x = minX; x <= maxX; x++)
+                {
+                    Float3 cellCenter = new Float3(
+                        gridOrigin.X + (x + 0.5f) * cellSize,
+                        gridOrigin.Y + (y + 0.5f) * cellSize,
+                        gridOrigin.Z + (z + 0.5f) * cellSize
+                    );
 
-            var a = ToInt(blockOrientation.Multiply(ref offsetNegative));
-            var b = ToInt(blockOrientation.Multiply(ref offsetPositive));
-
-            var minI = new Vector3i(Math.Min(a.x, b.x), Math.Min(a.y, b.y), Math.Min(a.z, b.z));
-            return blockSize.Min - minI;
+                    if (CheckTriangleBoxIntersection(tri, cellCenter, cellSize))
+                    {
+                        int flatIndex = x + (y * gridX) + (z * gridX * gridY);
+                        Atomic.Exchange(ref voxelGrid[flatIndex], 0);
+                    }
+                }
+            }
         }
+    }
 
-        static Vector3i ToInt(Vector3d vec)
-        {
-            return new
-            (
-                (int) Math.Round(vec.x),
-                (int) Math.Round(vec.y),
-                (int) Math.Round(vec.z)
-            );
-        }
+    private static bool CheckTriangleBoxIntersection(GpuTriangle tri, Float3 boxCenter, float cellSize)
+    {
+        float boxHalf = cellSize * 0.5f;
+
+        // Shift triangle to local AABB coordinate space
+        float v0X = tri.V0.X - boxCenter.X; float v0Y = tri.V0.Y - boxCenter.Y; float v0Z = tri.V0.Z - boxCenter.Z;
+        float v1X = tri.V1.X - boxCenter.X; float v1Y = tri.V1.Y - boxCenter.Y; float v1Z = tri.V1.Z - boxCenter.Z;
+        float v2X = tri.V2.X - boxCenter.X; float v2Y = tri.V2.Y - boxCenter.Y; float v2Z = tri.V2.Z - boxCenter.Z;
+
+        // Compute edge vectors
+        float e0X = v1X - v0X; float e0Y = v1Y - v0Y; float e0Z = v1Z - v0Z;
+        float e1X = v2X - v1X; float e1Y = v2Y - v1Y; float e1Z = v2Z - v1Z;
+        float e2X = v0X - v2X; float e2Y = v0Y - v2Y; float e2Z = v0Z - v2Z;
+
+        // SAT Test 1: Box AABB bounds
+        if (Min3(v0X, v1X, v2X) > boxHalf || Max3(v0X, v1X, v2X) < -boxHalf) return false;
+        if (Min3(v0Y, v1Y, v2Y) > boxHalf || Max3(v0Y, v1Y, v2Y) < -boxHalf) return false;
+        if (Min3(v0Z, v1Z, v2Z) > boxHalf || Max3(v0Z, v1Z, v2Z) < -boxHalf) return false;
+
+        // SAT Test 2: Triangle Plane vs Box Overlap
+        float normalX = e0Y * e1Z - e0Z * e1Y;
+        float normalY = e0Z * e1X - e0X * e1Z;
+        float normalZ = e0X * e1Y - e0Y * e1X;
+
+        float d = -(normalX * v0X + normalY * v0Y + normalZ * v0Z);
+
+        float vminX = normalX > 0f ? -boxHalf : boxHalf; float vmaxX = normalX > 0f ? boxHalf : -boxHalf;
+        float vminY = normalY > 0f ? -boxHalf : boxHalf; float vmaxY = normalY > 0f ? boxHalf : -boxHalf;
+        float vminZ = normalZ > 0f ? -boxHalf : boxHalf; float vmaxZ = normalZ > 0f ? boxHalf : -boxHalf;
+
+        if ((normalX * vminX + normalY * vminY + normalZ * vminZ) + d > 0f) return false;
+        if ((normalX * vmaxX + normalY * vmaxY + normalZ * vmaxZ) + d < 0f) return false;
+
+        // SAT Test 3: Edge Cross Products
+        if (!AxisTest(e0Z, -e0Y, v0Y, v0Z, v2Y, v2Z, boxHalf)) return false;
+        if (!AxisTest(e1Z, -e1Y, v1Y, v1Z, v0Y, v0Z, boxHalf)) return false;
+        if (!AxisTest(e2Z, -e2Y, v2Y, v2Z, v1Y, v1Z, boxHalf)) return false;
+
+        if (!AxisTest(-e0Z, e0X, v0X, v0Z, v2X, v2Z, boxHalf)) return false;
+        if (!AxisTest(-e1Z, e1X, v1X, v1Z, v0X, v0Z, boxHalf)) return false;
+        if (!AxisTest(-e2Z, e2X, v2X, v2Z, v1X, v1Z, boxHalf)) return false;
+
+        if (!AxisTest(e0Y, -e0X, v0X, v0Y, v2X, v2Y, boxHalf)) return false;
+        if (!AxisTest(e1Y, -e1X, v1X, v1Y, v0X, v0Y, boxHalf)) return false;
+        if (!AxisTest(e2Y, -e2X, v2X, v2Y, v1X, v1Y, boxHalf)) return false;
+
+        return true;
+    }
+
+    private static bool AxisTest(float a, float b, float fa, float fb, float va, float vb, float boxHalf)
+    {
+        float p0 = a * fa + b * fb;
+        float p2 = a * va + b * vb;
+        float min = Min(p0, p2);
+        float max = Max(p0, p2);
+        float rad = (Abs(a) + Abs(b)) * boxHalf;
+        return !(min > rad || max < -rad);
     }
 }

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -1,7 +1,5 @@
-﻿using System.Configuration;
-using System.Data;
+﻿using SpaceEditor.Data;
 using System.Windows;
-using SpaceEditor.Data;
 
 namespace SpaceEditor
 {

--- a/Controls/AsyncView.xaml.cs
+++ b/Controls/AsyncView.xaml.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
 
 namespace SpaceEditor.Controls;
@@ -15,7 +11,7 @@ public partial class AsyncView : UserControl
     {
         this.DataContextChanged += OnDataContextChanged;
         this.Unloaded += OnUnloaded;
-        
+
         InitializeComponent();
     }
 
@@ -34,7 +30,7 @@ public partial class AsyncView : UserControl
 
         this.Lifetime?.Cancel();
         this.Lifetime = new();
-        
+
         var lifetime = this.Lifetime.Token;
 
         this.LoadingContent.Visibility = Visibility.Visible;
@@ -45,7 +41,7 @@ public partial class AsyncView : UserControl
             try
             {
                 await data.WaitAsync(lifetime);
-                
+
                 this.LoadingContent.Visibility = Visibility.Collapsed;
                 this.MainContent.Visibility = Visibility.Visible;
             }

--- a/Controls/BlueprintGenerator.xaml
+++ b/Controls/BlueprintGenerator.xaml
@@ -6,7 +6,8 @@
              xmlns:local="clr-namespace:SpaceEditor.Controls"
              xmlns:colorPicker="clr-namespace:ColorPicker;assembly=ColorPicker"
              mc:Ignorable="d" 
-             d:DesignHeight="450" d:DesignWidth="800">
+             d:DesignHeight="450" d:DesignWidth="800"
+             PreviewKeyDown="UserControl_PreviewKeyDown">
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
@@ -47,10 +48,40 @@
                     <local:ReflectedObject x:Name="ModelSettings" Grid.Column="1" />
                 </Grid>
 
-                <Button
-                    Click="GenerateBlueprint"
-                    Content="The Preview looks good. Convert it to Blueprint!"
-                />
+                <Grid>
+                    <Button x:Name="GenerateButton" Click="GenerateBlueprint" Content="The Preview looks good. Convert it to Blueprint!" ToolTipService.Placement="Mouse">
+                        <Button.ToolTip>
+                            <ToolTip>
+                                <StackPanel Orientation="Vertical" Margin="2">
+                                    <!-- Header -->
+                                    <TextBlock Text="Generation Controls" FontWeight="Bold" Margin="0,0,0,4" />
+
+                                    <!-- Description -->
+                                    <TextBlock Text="Will generate a blueprint based on the loaded model on the right and the selected options above." />
+                                    <TextBlock Text="Blueprint will be layed over the model, use the Draw and Xray toggles for both to adjust the view." />
+                                    <TextBlock Text="Hold 'Shift' while clicking the button to use CPU instead of GPU." />
+                                    <TextBlock Text="It's slower and more likely to hang, use it if the process fails for some reason." />
+                                    <TextBlock Text="In any case, you can press the 'Esc' key once the blueprint generation is running to cancel it." />
+                                </StackPanel>
+                            </ToolTip>
+                        </Button.ToolTip>
+                    </Button>
+                    <Grid x:Name="ProgressOverlay" Visibility="Collapsed">
+                        <ProgressBar
+                            x:Name="GenerateProgress"
+                            Minimum="0" Maximum="100" Value="0"
+                            Height="25"
+                        />
+                        <TextBlock
+                            x:Name="ProgressText"
+                            Text="Initializing..."
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Foreground="Black"
+                            FontWeight="SemiBold"
+                        />
+                    </Grid>
+                </Grid>
             </StackPanel>
 
             <StackPanel

--- a/Controls/BlueprintGenerator.xaml.cs
+++ b/Controls/BlueprintGenerator.xaml.cs
@@ -300,7 +300,10 @@ public partial class BlueprintGenerator : UserControl
             {
                 // Guarantee the UI resets and the generate button is visible even if generation fails or is cancelled
                 this.GenerateButton.Visibility = Visibility.Visible;
-                this.GenerateProgress.Visibility = Visibility.Collapsed;
+
+                // Explicitly collapse the entire overlay grid, NOT just the inner progress bar
+                this.ProgressOverlay.Visibility = Visibility.Collapsed;
+
                 // Explicitly hide and clear the text block
                 this.ProgressText.Visibility = Visibility.Collapsed;
                 this.ProgressText.Text = string.Empty;

--- a/Controls/BlueprintGenerator.xaml.cs
+++ b/Controls/BlueprintGenerator.xaml.cs
@@ -4,10 +4,7 @@ using Microsoft.Win32;
 using SpaceEditor.Algorithms;
 using SpaceEditor.Data;
 using SpaceEditor.Rocks;
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Windows;
 using System.Windows.Controls;
@@ -30,7 +27,7 @@ public record ModelSettings
 
     [ButtonProperty(nameof(RecenterImp))]
     public bool Recenter { get; set; }
-    
+
     public float ModelSize { get; set; }
 
     [ButtonProperty(nameof(ScareToTargetSize))]
@@ -57,13 +54,13 @@ public record ModelSettings
         {
             var bb = model.CachedBounds;
             var dimensions = bb.Extents * 2;
-            
+
             var size = dimensions.MaxAbs;
             var targetSize = Math.Max(this.ModelSize, 1);
 
             MeshTransforms.Scale
             (
-                model, 
+                model,
                 new(targetSize / size),
                 bb.Center
             );
@@ -123,7 +120,7 @@ public partial class BlueprintGenerator : UserControl
     public DMesh3? Model;
     public AsyncLazy<DMeshAABBTree3>? ModelBVH;
     public CancellationTokenSource? ModelLifetime;
-        
+
     public CancellationTokenSource? GeneratorLifetime;
 
     private void UserControl_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
@@ -137,12 +134,12 @@ public partial class BlueprintGenerator : UserControl
 
     private ModelSettings ModelSettingsVM
     {
-        get => (ModelSettings) this.ModelSettings.ReflectedInstance;
+        get => (ModelSettings)this.ModelSettings.ReflectedInstance;
         set
         {
             // Make sure to reload the new values
             this.ModelSettings.ReflectedInstance = null!;
-            
+
             this.ModelSettings.ReflectedInstance = value;
         }
     }
@@ -172,7 +169,7 @@ public partial class BlueprintGenerator : UserControl
             model = LoadModel(selectFile.FileName);
             this.BlueprintName.Text = Path.GetFileNameWithoutExtension(selectFile.FileName);
 
-            
+
 
         }
         catch
@@ -202,7 +199,7 @@ public partial class BlueprintGenerator : UserControl
         this.ModelBVH.Poke();
 
         var bb = this.Model.CachedBounds;
-        this.ModelSettingsVM = this.ModelSettingsVM with { ModelSize = (float) bb.Extents.MaxAbs * 2 };
+        this.ModelSettingsVM = this.ModelSettingsVM with { ModelSize = (float)bb.Extents.MaxAbs * 2 };
 
         var modelInfo = new StringBuilder();
         modelInfo.AppendLine($"Model: {this.BlueprintName.Text}");
@@ -239,6 +236,7 @@ public partial class BlueprintGenerator : UserControl
 
     private async void GenerateBlueprint(object sender, RoutedEventArgs e)
     {
+        string mode;
         // Prevent accidental double-clicks from spawning multiple tasks
         if (this.IsGenerating) return;
         this.IsGenerating = true;
@@ -281,6 +279,9 @@ public partial class BlueprintGenerator : UserControl
 
             BlueprintMesh blueprint;
 
+            // Start the high-precision stopwatch right before dispatching
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
             try
             {
                 // Offload execution to a background thread, routing to CPU or GPU based on the flag
@@ -308,7 +309,8 @@ public partial class BlueprintGenerator : UserControl
                 this.ProgressText.Visibility = Visibility.Collapsed;
                 this.ProgressText.Text = string.Empty;
 
-                this.IsGenerating = false; // Unlock the UI
+                // Do NOT unlock IsGenerating here or stop the stopwatch yet. 
+                // The UI thread still needs to build and render the mesh!
             }
 
             // The code below automatically resumes on the UI thread
@@ -327,7 +329,13 @@ public partial class BlueprintGenerator : UserControl
 
             Vector3i dimensions = GetBlueprintDiemensions(usedIndicies);
 
-            string info = $"Blocks: X: {dimensions.x} Y: {dimensions.y} Z: {dimensions.z} Total: {usedIndicies.Count()}";
+            // The meshing and viewport rendering is finished. Now we stop the stopwatch.
+            stopwatch.Stop();
+
+            mode = isCpuFallback ? "CPU" : "GPU";
+            System.Diagnostics.Debug.WriteLine($"\n[PERFORMANCE] Blueprint generated in {stopwatch.Elapsed.TotalSeconds:F3} seconds using {mode}.\n");
+
+            string info = $"Blocks: X: {dimensions.x} Y: {dimensions.y} Z: {dimensions.z} Total: {usedIndicies.Count()}\nTime: {stopwatch.Elapsed.TotalSeconds:F2}s (generated using {mode})";
             this.BlueprintDetails.Text = info;
 
             lifetime.Register(() =>
@@ -347,7 +355,7 @@ public partial class BlueprintGenerator : UserControl
         }
         finally
         {
-            this.IsGenerating = false; // Failsafe unlock
+            this.IsGenerating = false; // Failsafe unlock AFTER everything is done
         }
     }
 
@@ -355,14 +363,14 @@ public partial class BlueprintGenerator : UserControl
     {
         AxisAlignedBox3i dimensions = AxisAlignedBox3i.Empty;
 
-		foreach (Vector3i v3i in indicies)
+        foreach (Vector3i v3i in indicies)
         {
             dimensions.Contain(v3i);
         }
 
         return dimensions.Diagonal + 1;
     }
-        
+
     private void ExportBlueprint(object sender, RoutedEventArgs e)
     {
         var blueprint = (BlueprintMesh)this.ExportBlueprintPanel.Tag;
@@ -391,10 +399,10 @@ public partial class BlueprintGenerator : UserControl
         saveLocation.AddExtension = true;
         saveLocation.DefaultExt = "obj";
         saveLocation.FileName = this.BlueprintName.Text;
-        
+
         if (saveLocation.ShowDialog() != true)
             return;
-        
+
         var mesh = GridMesher.Mesh(blueprint);
         Util.WriteDebugMesh(mesh, saveLocation.FileName);
     }
@@ -409,7 +417,7 @@ public partial class BlueprintGenerator : UserControl
         foreach (var m in scene.Meshes)
         {
             var vertexIndices = new List<int>();
-                
+
             var vertices = m.Vertices;
             var normals = m.HasNormals ? m.Normals : null;
             var uvs = m.HasTextureCoords(0) ? m.TextureCoordinateChannels[0] : null;
@@ -484,15 +492,15 @@ public partial class BlueprintGenerator : UserControl
     {
         var controls = this.ViewportControls.Children.OfType<FrameworkElement>().Where(x => Grid.GetRow(x) == controlsRow).ToArray();
 
-        var draw = (CheckBox) controls[1];
-        var xray = (CheckBox) controls[2];
-        var color = (ColourSlider) controls[3];
+        var draw = (CheckBox)controls[1];
+        var xray = (CheckBox)controls[2];
+        var color = (ColourSlider)controls[3];
 
         var renderData = new ModelViewport.ModelData
         {
             Mesh = model,
         };
-            
+
         RoutedEventHandler onCheckedChanged = (_, _) =>
         {
             renderData.Color = color.SelectedColour;

--- a/Controls/BlueprintGenerator.xaml.cs
+++ b/Controls/BlueprintGenerator.xaml.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Text;
 using System.Windows;
 using System.Windows.Controls;
+using static SpaceEditor.Algorithms.GridShaper;
 
 namespace SpaceEditor.Controls;
 
@@ -97,6 +98,10 @@ public record ModelSettings
 
     private void UpdateModelCopy(Action<DMesh3> update)
     {
+        // Block model modifications while a generation is running
+        // Prevents the accidental cancellation of a generation due to a button press in the blueprint menu
+        if (this.Screen.IsGenerating) return;
+
         var model = this.Screen.Model;
         if (model is null)
             return;
@@ -113,11 +118,22 @@ public record ModelSettings
 /// </summary>
 public partial class BlueprintGenerator : UserControl
 {
+    public bool IsGenerating { get; private set; } = false;
+
     public DMesh3? Model;
     public AsyncLazy<DMeshAABBTree3>? ModelBVH;
     public CancellationTokenSource? ModelLifetime;
         
     public CancellationTokenSource? GeneratorLifetime;
+
+    private void UserControl_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+    {
+        if (e.Key == System.Windows.Input.Key.Escape)
+        {
+            this.GeneratorLifetime?.Cancel();
+            e.Handled = true;
+        }
+    }
 
     private ModelSettings ModelSettingsVM
     {
@@ -143,6 +159,9 @@ public partial class BlueprintGenerator : UserControl
 
     private void SelectModel(object sender, RoutedEventArgs e)
     {
+        // Block new file selection while a generation is running
+        if (this.IsGenerating) return;
+
         var selectFile = new OpenFileDialog();
         if (selectFile.ShowDialog(Window.GetWindow(this)) != true)
             return;
@@ -192,12 +211,12 @@ public partial class BlueprintGenerator : UserControl
         var modelSize = Math.Max(bb.Min.MaxAbs, bb.Max.MaxAbs) * 2;
         if (modelSize > 3000)
         {
-            modelInfo.AppendLine("Mode is too larget to safely convert.");
+            modelInfo.AppendLine("Model is too large to safely convert.");
             modelInfo.AppendLine("Scale it down.");
         }
         else if (modelSize > 500)
         {
-            modelInfo.AppendLine("Mode is quite large, performance issues may appear.");
+            modelInfo.AppendLine("Model is quite large, performance issues may appear.");
             modelInfo.AppendLine("Recommended to scale it down.");
         }
 
@@ -220,23 +239,76 @@ public partial class BlueprintGenerator : UserControl
 
     private async void GenerateBlueprint(object sender, RoutedEventArgs e)
     {
+        // Prevent accidental double-clicks from spawning multiple tasks
+        if (this.IsGenerating) return;
+        this.IsGenerating = true;
+
         try
         {
+            // Capture the state of the Shift key at the exact moment of the click
+            bool isCpuFallback = System.Windows.Input.Keyboard.Modifiers.HasFlag(System.Windows.Input.ModifierKeys.Shift);
+
             var lifetime = ResetLifetime(ref this.GeneratorLifetime, this.ModelLifetime);
 
             var model = this.Model;
             if (model is null)
                 return;
-                
-            var tree = await this.ModelBVH!.Value;
-                
-            var shaper = new GridShaper(model, tree);
-            var blueprint = shaper.Generate
-            (
-                (GridShaper.GeneratorSettings) this.GeneratorSettings.ReflectedInstance,
-                lifetime
-            );
 
+            var tree = await this.ModelBVH!.Value;
+            var shaper = new GridShaper(model, tree);
+            var settings = (GridShaper.GeneratorSettings)this.GeneratorSettings.ReflectedInstance;
+
+            // Hide the button and show the progress overlay
+            this.GenerateButton.Visibility = Visibility.Collapsed;
+            this.ProgressOverlay.Visibility = Visibility.Visible;
+            this.GenerateProgress.Value = 0;
+            this.ProgressText.Visibility = Visibility.Visible; // Explicitly show the text
+            this.ProgressText.Text = "Initializing...";
+
+            // Without this, the esc button dosen't work because the bluepring generation button was colapsed to make place for the progress bar
+            this.Focusable = true;
+            System.Windows.Input.Keyboard.Focus(this);
+
+            // Display the CPU/GPU indicator text
+            this.BlueprintDetails.Text = isCpuFallback ? "Generating via CPU (Shift fallback)..." : "Generating via GPU...";
+
+            // Route background progress updates back to the UI thread
+            var progress = new Progress<(double Value, string Message)>(p =>
+            {
+                this.GenerateProgress.Value = p.Value * 100;
+                this.ProgressText.Text = p.Message;
+            });
+
+            BlueprintMesh blueprint;
+
+            try
+            {
+                // Offload execution to a background thread, routing to CPU or GPU based on the flag
+                blueprint = await Task.Run(() =>
+                {
+                    if (isCpuFallback)
+                    {
+                        return shaper.GenerateCpu(settings, lifetime, progress);
+                    }
+                    else
+                    {
+                        return shaper.Generate(settings, lifetime, progress);
+                    }
+                }, lifetime);
+            }
+            finally
+            {
+                // Guarantee the UI resets and the generate button is visible even if generation fails or is cancelled
+                this.GenerateButton.Visibility = Visibility.Visible;
+                this.GenerateProgress.Visibility = Visibility.Collapsed;
+                // Explicitly hide and clear the text block
+                this.ProgressText.Visibility = Visibility.Collapsed;
+                this.ProgressText.Text = string.Empty;
+
+                this.IsGenerating = false; // Unlock the UI
+            }
+
+            // The code below automatically resumes on the UI thread
             var gridMesh = GridMesher.Mesh(blueprint);
             var modelRender = CreateRenderModel(gridMesh, controlsRow: 1);
             lifetime.Register(() =>
@@ -253,16 +325,26 @@ public partial class BlueprintGenerator : UserControl
             Vector3i dimensions = GetBlueprintDiemensions(usedIndicies);
 
             string info = $"Blocks: X: {dimensions.x} Y: {dimensions.y} Z: {dimensions.z} Total: {usedIndicies.Count()}";
-			this.BlueprintDetails.Text = info;
+            this.BlueprintDetails.Text = info;
 
             lifetime.Register(() =>
             {
                 this.BlueprintDetails.Text = null;
             });
         }
-        catch
+        catch (OperationCanceledException)
         {
-                
+            // Silently catch the cancellation so it doesn't crash the app
+            this.BlueprintDetails.Text = "Generation cancelled.";
+        }
+        catch (Exception ex)
+        {
+            // Handle other general exceptions
+            this.BlueprintDetails.Text = "Generation failed. See logs.";
+        }
+        finally
+        {
+            this.IsGenerating = false; // Failsafe unlock
         }
     }
 

--- a/Controls/ButtonPropertyGridControlFactory.cs
+++ b/Controls/ButtonPropertyGridControlFactory.cs
@@ -15,7 +15,7 @@ public class ButtonPropertyGridControlFactory : IControlFactory
 {
     public FrameworkElement? TryCreateControl(PropertyItem property, PropertyControlFactoryOptions options)
     {
-        if (property.Descriptor.GetFirstAttributeOrDefault<ButtonPropertyAttribute>() is not {} target)
+        if (property.Descriptor.GetFirstAttributeOrDefault<ButtonPropertyAttribute>() is not { } target)
             return null;
 
         var button = new Button();

--- a/Controls/CharacterEditor.xaml.cs
+++ b/Controls/CharacterEditor.xaml.cs
@@ -1,16 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
+﻿using ColorPicker.Models;
+using SpaceEditor.Data;
+using SpaceEditor.Data.GameLinks;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using ColorPicker.Models;
-using SpaceEditor.Data;
-using SpaceEditor.Data.GameLinks;
 
 namespace SpaceEditor.Controls;
 
@@ -26,7 +22,7 @@ public partial class CharacterEditor : UserControl
 
     // Non-null value signifies initialization is done
     public volatile NotifyableColor? Color;
-    
+
     private readonly GameLink GameLink;
 
     private bool IsConnectedToGameImpl;
@@ -53,7 +49,7 @@ public partial class CharacterEditor : UserControl
     public CharacterEditor(GameProxy game, GameLink gameLink)
     {
         this.GameLink = gameLink;
-        
+
         InitializeComponent();
         this.IsConnectedToGame = false;
 
@@ -65,8 +61,8 @@ public partial class CharacterEditor : UserControl
 
         this.SecondaryColor.SecondaryColor = System.Windows.Media.Color.FromRgb
         (
-            0xff, 
-            0x2a, 
+            0xff,
+            0x2a,
             0x1f
         );
 
@@ -74,7 +70,7 @@ public partial class CharacterEditor : UserControl
         {
             this.Albedo = Read("Resources/CharacterEditor/Albedo.png");
             this.Mask = Read("Resources/CharacterEditor/Mask.png");
-            this.OutputMemoryPool = (Argb32[,]) this.Albedo.Clone();
+            this.OutputMemoryPool = (Argb32[,])this.Albedo.Clone();
 
             var dpi = VisualTreeHelper.GetDpi(this);
             var previewBitmap = this.Dispatcher.Invoke(() =>
@@ -88,7 +84,7 @@ public partial class CharacterEditor : UserControl
                     PixelFormats.Bgra32,
                     null
                 );
-                
+
                 Write(previewBitmap, this.Albedo);
                 return previewBitmap;
             });
@@ -122,7 +118,7 @@ public partial class CharacterEditor : UserControl
 
         async Task Impl()
         {
-            Run:
+        Run:
             this.NeedsUpdate = false;
 
             var suitColor = new Argb32
@@ -142,22 +138,22 @@ public partial class CharacterEditor : UserControl
                 var w = albedo.GetLength(1);
                 var h = albedo.GetLength(0);
                 for (int x = 0; x < w; x++)
-                for (int y = 0; y < h; y++)
-                {
-                    var c1 = albedo[y, x];
-                    var c2 = mask[y, x];
-
-                    if (c2 with {A = default } != default)
+                    for (int y = 0; y < h; y++)
                     {
-                        c1 = MultiplyColors(c1, MultiplyColors(c2, suitColor));
-                    }
+                        var c1 = albedo[y, x];
+                        var c2 = mask[y, x];
 
-                    output[y, x] = c1;
-                }
+                        if (c2 with { A = default } != default)
+                        {
+                            c1 = MultiplyColors(c1, MultiplyColors(c2, suitColor));
+                        }
+
+                        output[y, x] = c1;
+                    }
 
                 return output;
             });
-            
+
             await SendToGameIfNeeded();
 
             Write(this.PreviewBitmap, await bitmapCompute);
@@ -173,10 +169,10 @@ public partial class CharacterEditor : UserControl
     {
         return new()
         {
-            B = (byte) (Math.Round((c1.R / 255.0) * (c2.R / 255.0) * 255.0)),
-            G = (byte) (Math.Round((c1.G / 255.0) * (c2.G / 255.0) * 255.0)),
-            R = (byte) (Math.Round((c1.B / 255.0) * (c2.B / 255.0) * 255.0)),
-            A = (byte) (Math.Round((c1.A / 255.0) * (c2.A / 255.0) * 255.0)),
+            B = (byte)(Math.Round((c1.R / 255.0) * (c2.R / 255.0) * 255.0)),
+            G = (byte)(Math.Round((c1.G / 255.0) * (c2.G / 255.0) * 255.0)),
+            R = (byte)(Math.Round((c1.B / 255.0) * (c2.B / 255.0) * 255.0)),
+            A = (byte)(Math.Round((c1.A / 255.0) * (c2.A / 255.0) * 255.0)),
         };
     }
 
@@ -272,10 +268,10 @@ public partial class CharacterEditor : UserControl
         this.LastConnectionTask = connectionTask;
 
         PrintStatus(success: "Testing connection ...");
-        
-        var button = (Button) sender;
+
+        var button = (Button)sender;
         button.IsEnabled = false;
-        
+
         Exception? connectionError = null;
         try
         {
@@ -294,7 +290,7 @@ public partial class CharacterEditor : UserControl
             // Throw if anything is stored inside
             await connectionTask;
         }
-        catch(Exception e)
+        catch (Exception e)
         {
             connectionError = e;
         }
@@ -317,19 +313,19 @@ public partial class CharacterEditor : UserControl
         this.LastConnectionTask = Task.CompletedTask;
         this.IsConnectedToGame = false;
     }
-    
+
     private async Task SendToGameIfNeeded()
     {
         if (this.Color is null)
             return;
-        
+
         if (this.IsConnectedToGame == false)
             return;
 
-        uint colorInt = ((uint) byte.MaxValue << 24) |
-                        ((uint) (byte) (this.Color.RGB_R) << 16) |
-                        ((uint) (byte) (this.Color.RGB_G) << 8) |
-                        ((uint) (byte) (this.Color.RGB_B) << 0);
+        uint colorInt = ((uint)byte.MaxValue << 24) |
+                        ((uint)(byte)(this.Color.RGB_R) << 16) |
+                        ((uint)(byte)(this.Color.RGB_G) << 8) |
+                        ((uint)(byte)(this.Color.RGB_B) << 0);
 
         var error = await Task.Run(async () =>
         {
@@ -337,7 +333,7 @@ public partial class CharacterEditor : UserControl
             {
                 await this.GameLink.PaintCharacters(colorInt);
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 return e;
             }
@@ -351,12 +347,12 @@ public partial class CharacterEditor : UserControl
     private void PrintStatus(Exception? error = null, string? success = null)
     {
         var message = success;
-        
+
         if (error is not null)
         {
-            message = error.Message + 
-                      Environment.NewLine + 
-                      Environment.NewLine + 
+            message = error.Message +
+                      Environment.NewLine +
+                      Environment.NewLine +
                       error.ToString();
         }
 

--- a/Controls/ColourSlider.xaml.cs
+++ b/Controls/ColourSlider.xaml.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Threading;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Controls.Primitives;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 
@@ -58,7 +55,7 @@ public class ColourSlider : Slider
 
     public Color SelectedColour
     {
-        get { return (Color) this.GetValue(SelectedColoursProperty); }
+        get { return (Color)this.GetValue(SelectedColoursProperty); }
         set { this.SetValue(SelectedColoursProperty, value); }
     }
 
@@ -76,7 +73,7 @@ public class ColourSlider : Slider
         {
             if (this.CacheBitmap() == false)
                 return;
-            
+
             this.SetColour(this.SelectedColour);
             this.isFirstTime = false;
         }
@@ -91,11 +88,11 @@ public class ColourSlider : Slider
             {
                 this.isValueUpdating = true;
 
-                if (this.colourGradient is {} bitmap)
+                if (this.colourGradient is { } bitmap)
                 {
                     // work out the track position based on the control's width
                     double width = this.colourGradient.Width;
-                    int position = (int) (((newValue - base.Minimum) / (base.Maximum - base.Minimum)) * width);
+                    int position = (int)(((newValue - base.Minimum) / (base.Maximum - base.Minimum)) * width);
 
                     this.SelectedColour = GetColour(bitmap, position);
                     RaiseEvent(new(ColorChangedEvent, this));
@@ -160,10 +157,10 @@ public class ColourSlider : Slider
     {
         if (position >= bitmap.Width - 1)
         {
-            position = (int) bitmap.Width - 2;
+            position = (int)bitmap.Width - 2;
         }
 
-        CroppedBitmap cb = new CroppedBitmap(bitmap, new Int32Rect(position, (int) this.VisualBounds.Height / 2, 1, 1));
+        CroppedBitmap cb = new CroppedBitmap(bitmap, new Int32Rect(position, (int)this.VisualBounds.Height / 2, 1, 1));
         byte[] tricolour = new byte[4];
 
         cb.CopyPixels(tricolour, 4, 0);
@@ -178,7 +175,7 @@ public class ColourSlider : Slider
         if (double.IsInfinity(bounds.Width) || double.IsInfinity(bounds.Height))
             return false;
 
-        RenderTargetBitmap source = new RenderTargetBitmap((int) bounds.Width, (int) bounds.Height, 96, 96, PixelFormats.Pbgra32);
+        RenderTargetBitmap source = new RenderTargetBitmap((int)bounds.Width, (int)bounds.Height, 96, 96, PixelFormats.Pbgra32);
 
         DrawingVisual dv = new DrawingVisual();
 
@@ -195,8 +192,8 @@ public class ColourSlider : Slider
 
     private static void SelectedColourChangedCallBack(DependencyObject property, DependencyPropertyChangedEventArgs args)
     {
-        ColourSlider colourSlider = (ColourSlider) property;
-        Color colour = (Color) args.NewValue;
+        ColourSlider colourSlider = (ColourSlider)property;
+        Color colour = (Color)args.NewValue;
 
         colourSlider.SetColour(colour);
     }
@@ -215,7 +212,7 @@ public class ColourSlider : Slider
 
     public static System.Drawing.Color ToDrawingColour(Color source)
     {
-        return System.Drawing.Color.FromArgb((int) source.R, (int) source.G, (int) source.B);
+        return System.Drawing.Color.FromArgb((int)source.R, (int)source.G, (int)source.B);
     }
 
     #endregion

--- a/Controls/CompositePropertyGridControlFactory.cs
+++ b/Controls/CompositePropertyGridControlFactory.cs
@@ -1,7 +1,4 @@
 ﻿using PropertyTools.Wpf;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Windows;
 
 namespace SpaceEditor.Controls;
@@ -22,9 +19,9 @@ public class CompositePropertyGridControlFactory : PropertyGridControlFactory, I
 
     public virtual FrameworkElement? TryCreateControl(PropertyItem property, PropertyControlFactoryOptions options)
     {
-        foreach(var factory in this.Factories)
+        foreach (var factory in this.Factories)
         {
-            if (factory.TryCreateControl(property, options) is {} control)
+            if (factory.TryCreateControl(property, options) is { } control)
             {
                 return control;
             }

--- a/Controls/FlatGroupingDataGridOperator.cs
+++ b/Controls/FlatGroupingDataGridOperator.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using PropertyTools.Wpf;
+﻿using PropertyTools.Wpf;
 
 namespace SpaceEditor.Controls;
 

--- a/Controls/InputIdControlsFactory.cs
+++ b/Controls/InputIdControlsFactory.cs
@@ -1,9 +1,9 @@
-﻿using System.Collections;
+﻿using PropertyTools.Wpf;
+using SpaceEditor.Data;
+using System.Collections;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
-using PropertyTools.Wpf;
-using SpaceEditor.Data;
 
 namespace SpaceEditor.Controls;
 
@@ -35,9 +35,9 @@ public class InputIdControlsFactory : IControlFactory
         {
             var inputIds = property.Descriptor.ComponentType.Name switch
             {
-                {} s when s.StartsWith("Digital") => this.InputIds.Digitals,
-                {} s when s.StartsWith("Analog") => this.InputIds.Analogs,
-                {} s when s.StartsWith("Pointer") => this.InputIds.Pointers,
+                { } s when s.StartsWith("Digital") => this.InputIds.Digitals,
+                { } s when s.StartsWith("Analog") => this.InputIds.Analogs,
+                { } s when s.StartsWith("Pointer") => this.InputIds.Pointers,
             };
 
             var keyValueInputs = inputIds.Select(x =>

--- a/Controls/InputsEditor.xaml.cs
+++ b/Controls/InputsEditor.xaml.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using ReflectionMagic;
+using SpaceEditor.Data;
 using System.ComponentModel;
-using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
-using ReflectionMagic;
-using SpaceEditor.Data;
 
 namespace SpaceEditor.Controls;
 
@@ -46,7 +43,7 @@ public partial class InputsEditor : UserControl
             var cv = CollectionViewSource.GetDefaultView(vm.Actions.Actions.Select(x => x.Value).ToList());
             cv.Filter = x =>
             {
-                var candidate = ((InputActions.InputActionInfo) x).DisplayName;
+                var candidate = ((InputActions.InputActionInfo)x).DisplayName;
                 return candidate.Contains(this.InputActionsSearchString, StringComparison.InvariantCultureIgnoreCase);
             };
 
@@ -62,7 +59,7 @@ public partial class InputsEditor : UserControl
 
     private void OnInputActionSelected(object sender, SelectionChangedEventArgs e)
     {
-        var selected = (InputActions.InputActionInfo?) this.ActionList.SelectedValue;
+        var selected = (InputActions.InputActionInfo?)this.ActionList.SelectedValue;
         if (selected is null)
             goto Nothing;
 
@@ -81,7 +78,7 @@ public partial class InputsEditor : UserControl
         this.BindingsEditor.Visibility = Visibility.Visible;
         return;
 
-        Nothing:
+    Nothing:
         this.BindingsEditor.DataContext = null;
         this.BindingsEditor.ReflectedItems = null;
         this.BindingsEditor.Visibility = Visibility.Hidden;

--- a/Controls/KeyBindsEditor.xaml.cs
+++ b/Controls/KeyBindsEditor.xaml.cs
@@ -1,15 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
+﻿using ObservableCollections;
+using SpaceEditor.Data;
+using SpaceEditor.Rocks;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.IO;
-using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
-using ObservableCollections;
-using SpaceEditor.Data;
-using SpaceEditor.Rocks;
 
 namespace SpaceEditor.Controls;
 
@@ -19,9 +15,9 @@ namespace SpaceEditor.Controls;
 public partial class KeyBindsEditor : UserControl
 {
     private const string CurrentPreset = "Current";
-    
+
     public GameProxy Game { get; }
-    
+
     private Settings Settings => Settings.Default;
     public ObservableDictionary<string, string> Presets { get; } = new();
     public INotifyCollectionChanged PresetsView => this.Presets.ToNotifyCollectionChanged();
@@ -33,12 +29,12 @@ public partial class KeyBindsEditor : UserControl
         var mappingsFile = GameFacts.GetMappingFile(this.Game.BaseGamePath);
         var content = File.ReadAllText(mappingsFile);
         this.Presets.Add(CurrentPreset, content);
-        
+
         foreach (var (key, dataString) in this.Settings.NamedPresets)
         {
             this.Presets[key] = dataString;
         }
-        
+
         InitializeComponent();
     }
 
@@ -57,7 +53,7 @@ public partial class KeyBindsEditor : UserControl
 
     private void OnPresetChanged2(object? sender, EventArgs e)
     {
-        var key = (string?) this.PresetsCombo.SelectedValue;
+        var key = (string?)this.PresetsCombo.SelectedValue;
         if (key is null)
             return;
 
@@ -119,7 +115,7 @@ public partial class KeyBindsEditor : UserControl
 
     private void OnCurrentVM(Action<PresetVM> action)
     {
-        var vm = (PresetVM?) this.InputsEditorControl.DataContext;
+        var vm = (PresetVM?)this.InputsEditorControl.DataContext;
         if (vm is null)
             return;
 

--- a/Controls/ModelViewport.xaml.cs
+++ b/Controls/ModelViewport.xaml.cs
@@ -1,9 +1,7 @@
 ﻿using g4;
 using SpaceEditor.Data;
 using SpaceEditor.Rocks;
-using System;
 using System.ComponentModel;
-using System.Linq;
 using System.Numerics;
 using System.Windows;
 using System.Windows.Controls;
@@ -33,11 +31,11 @@ public partial class ModelViewport : UserControl
             get => this.ColorImpl;
             set => SetField(ref this.ColorImpl, value);
         }
-        
+
         public float Opacity
         {
-            get => (float) this.Color.A / byte.MaxValue;
-            set => this.Color = this.Color with {A = (byte)(value * byte.MaxValue) };
+            get => (float)this.Color.A / byte.MaxValue;
+            set => this.Color = this.Color with { A = (byte)(value * byte.MaxValue) };
         }
     }
 
@@ -59,7 +57,7 @@ public partial class ModelViewport : UserControl
         (
             m.Triangles().SelectMany(t =>
             {
-                return new[]{ t.a, t.b, t.c };
+                return new[] { t.a, t.b, t.c };
             })
         );
 
@@ -80,7 +78,7 @@ public partial class ModelViewport : UserControl
             Geometry = mesh,
             Transform = Transform3D.Identity
         };
-        
+
         var renderModel = new ModelVisual3D
         {
             Content = geometry
@@ -138,7 +136,7 @@ public partial class ModelViewport : UserControl
             return;
 
         var cameraPosition = this.Camera.Position;
-        UpdateObitCamera(default, ref cameraPosition, new(-(float) diff.X, (float) -diff.Y), 0.03f);
+        UpdateObitCamera(default, ref cameraPosition, new(-(float)diff.X, (float)-diff.Y), 0.03f);
         SetCameraParameters(cameraPosition);
     }
 

--- a/Controls/PCUUnlocker.xaml.cs
+++ b/Controls/PCUUnlocker.xaml.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using SpaceEditor.Data;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;
-using SpaceEditor.Data;
 
 namespace SpaceEditor.Controls;
 
@@ -53,7 +49,7 @@ public partial class PCUUnlocker : UserControl
                     const string PlayergridPCU = "\"PlayerGridPCU\"";
                     const string TargetCleanupLimit = "\"TargetCleanupLimit\"";
                     const string ExecuteCleanupLimit = "\"ExecuteCleanupLimit\"";
-                    
+
                     var gridSectionBegin = content.IndexOf(PlayergridPCU, StringComparison.InvariantCulture);
                     if (gridSectionBegin < 0)
                         return null;
@@ -83,12 +79,12 @@ public partial class PCUUnlocker : UserControl
 
         Settings.Default.InvokeGameAction(() =>
         {
-            foreach(var (file, newContent) in contents)
+            foreach (var (file, newContent) in contents)
             {
                 File.WriteAllText(file, newContent);
             }
         });
-        
+
         bool UpdateFile(string fileName, Func<string, string?> updateFunction)
         {
             var filePath = GameFacts.TryFindTargetPath(this.Game.ContentPath, [], fileName);
@@ -98,7 +94,7 @@ public partial class PCUUnlocker : UserControl
             }
 
             var content = contents.GetValueOrDefault(filePath) ?? File.ReadAllText(filePath);
-            
+
             var newContent = updateFunction(content);
             if (newContent is null)
                 return false;

--- a/Controls/ReflectedCollection.xaml.cs
+++ b/Controls/ReflectedCollection.xaml.cs
@@ -1,21 +1,8 @@
-﻿using System;
+﻿using SpaceEditor.Rocks;
 using System.Collections;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using SpaceEditor.Data;
-using SpaceEditor.Rocks;
 
 namespace SpaceEditor.Controls;
 
@@ -59,9 +46,9 @@ public partial class ReflectedCollection : UserControl
 
     private void RemoveBinding(object sender, RoutedEventArgs e)
     {
-        var v = (FrameworkElement) sender;
+        var v = (FrameworkElement)sender;
         var current = v.DataContext!;
-        
+
         UpdateCollection(x =>
         {
             x.Remove(current);
@@ -70,7 +57,7 @@ public partial class ReflectedCollection : UserControl
 
     private void AddElement(object sender, RoutedEventArgs e)
     {
-        var selectedType = (Type?) this.NewElementTypes.SelectedValue;
+        var selectedType = (Type?)this.NewElementTypes.SelectedValue;
         if (selectedType is null)
             return;
 
@@ -84,7 +71,7 @@ public partial class ReflectedCollection : UserControl
     {
         if (this.ReflectedItems is ICollectionView cv)
         {
-            update((IList) cv.SourceCollection);
+            update((IList)cv.SourceCollection);
             cv.Refresh();
             return;
         }

--- a/Controls/ReflectedObject.xaml.cs
+++ b/Controls/ReflectedObject.xaml.cs
@@ -1,11 +1,7 @@
-﻿using System;
+﻿using SpaceEditor.Rocks;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
-using SpaceEditor.Rocks;
 
 namespace SpaceEditor.Controls;
 
@@ -32,13 +28,13 @@ public partial class ReflectedObject : UserControl
 
     public object ReflectedInstance
     {
-        get { return (object) GetValue(ReflectedInstanceProperty); }
+        get { return (object)GetValue(ReflectedInstanceProperty); }
         set { SetValue(ReflectedInstanceProperty, value); }
     }
 
     public IEnumerable NewObjectTypeCandidates
     {
-        get { return (IEnumerable) GetValue(NewObjectTypeCandidatesProperty); }
+        get { return (IEnumerable)GetValue(NewObjectTypeCandidatesProperty); }
         set { SetValue(NewObjectTypeCandidatesProperty, value); }
     }
 
@@ -52,7 +48,7 @@ public partial class ReflectedObject : UserControl
         if (e.AddedItems.Count == 0)
             return;
 
-        var type = ((KeyValuePair<string, Type>) e.AddedItems[0]!).Value;
+        var type = ((KeyValuePair<string, Type>)e.AddedItems[0]!).Value;
         this.ReflectedInstance = type.AllocateObjectBuilder();
     }
 }

--- a/Data/GameFacts.cs
+++ b/Data/GameFacts.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
 
 namespace SpaceEditor.Data;
 
@@ -85,14 +82,14 @@ public static class GameFacts
             var testDir = Path.Combine(baseDirectory, currentDirToSearchFor);
             if (Directory.Exists(testDir))
             {
-                if (TryFindTargetPath(testDir, subDirectories[1..], targetFile, remainingSearchDepth) is {} result)
+                if (TryFindTargetPath(testDir, subDirectories[1..], targetFile, remainingSearchDepth) is { } result)
                     return result;
             }
         }
 
         foreach (var dir in Directory.EnumerateDirectories(baseDirectory))
         {
-            if (TryFindTargetPath(dir, subDirectories, targetFile, remainingSearchDepth) is {} result)
+            if (TryFindTargetPath(dir, subDirectories, targetFile, remainingSearchDepth) is { } result)
                 return result;
         }
 

--- a/Data/GameLinks/DbgShimResolver.cs
+++ b/Data/GameLinks/DbgShimResolver.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
 using System.Runtime.InteropServices;
 
 namespace SpaceEditor.Data.GameLinks;

--- a/Data/GameLinks/DebuggerCallbacks.cs
+++ b/Data/GameLinks/DebuggerCallbacks.cs
@@ -72,229 +72,229 @@ public static class DebuggerCallbacks
             if (typeof(T) == typeof(BreakpointCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<BreakpointCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnBreakpoint -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnBreakpoint -= handler; };
                 instance.OnBreakpoint += handler;
             }
             else if (typeof(T) == typeof(StepCompleteCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<StepCompleteCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnStepComplete -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnStepComplete -= handler; };
                 instance.OnStepComplete += handler;
             }
             else if (typeof(T) == typeof(BreakCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<BreakCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnBreak -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnBreak -= handler; };
                 instance.OnBreak += handler;
             }
             else if (typeof(T) == typeof(ExceptionCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<ExceptionCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnException -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnException -= handler; };
                 instance.OnException += handler;
             }
             else if (typeof(T) == typeof(EvalCompleteCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<EvalCompleteCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnEvalComplete -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnEvalComplete -= handler; };
                 instance.OnEvalComplete += handler;
             }
             else if (typeof(T) == typeof(EvalExceptionCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<EvalExceptionCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnEvalException -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnEvalException -= handler; };
                 instance.OnEvalException += handler;
             }
             else if (typeof(T) == typeof(CreateProcessCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<CreateProcessCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnCreateProcess -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnCreateProcess -= handler; };
                 instance.OnCreateProcess += handler;
             }
             else if (typeof(T) == typeof(ExitProcessCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<ExitProcessCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnExitProcess -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnExitProcess -= handler; };
                 instance.OnExitProcess += handler;
             }
             else if (typeof(T) == typeof(CreateThreadCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<CreateThreadCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnCreateThread -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnCreateThread -= handler; };
                 instance.OnCreateThread += handler;
             }
             else if (typeof(T) == typeof(ExitThreadCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<ExitThreadCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnExitThread -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnExitThread -= handler; };
                 instance.OnExitThread += handler;
             }
             else if (typeof(T) == typeof(LoadModuleCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<LoadModuleCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnLoadModule -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnLoadModule -= handler; };
                 instance.OnLoadModule += handler;
             }
             else if (typeof(T) == typeof(UnloadModuleCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<UnloadModuleCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnUnloadModule -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnUnloadModule -= handler; };
                 instance.OnUnloadModule += handler;
             }
             else if (typeof(T) == typeof(LoadClassCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<LoadClassCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnLoadClass -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnLoadClass -= handler; };
                 instance.OnLoadClass += handler;
             }
             else if (typeof(T) == typeof(UnloadClassCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<UnloadClassCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnUnloadClass -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnUnloadClass -= handler; };
                 instance.OnUnloadClass += handler;
             }
             else if (typeof(T) == typeof(DebuggerErrorCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<DebuggerErrorCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnDebuggerError -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnDebuggerError -= handler; };
                 instance.OnDebuggerError += handler;
             }
             else if (typeof(T) == typeof(LogMessageCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<LogMessageCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnLogMessage -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnLogMessage -= handler; };
                 instance.OnLogMessage += handler;
             }
             else if (typeof(T) == typeof(LogSwitchCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<LogSwitchCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnLogSwitch -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnLogSwitch -= handler; };
                 instance.OnLogSwitch += handler;
             }
             else if (typeof(T) == typeof(CreateAppDomainCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<CreateAppDomainCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnCreateAppDomain -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnCreateAppDomain -= handler; };
                 instance.OnCreateAppDomain += handler;
             }
             else if (typeof(T) == typeof(ExitAppDomainCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<ExitAppDomainCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnExitAppDomain -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnExitAppDomain -= handler; };
                 instance.OnExitAppDomain += handler;
             }
             else if (typeof(T) == typeof(LoadAssemblyCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<LoadAssemblyCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnLoadAssembly -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnLoadAssembly -= handler; };
                 instance.OnLoadAssembly += handler;
             }
             else if (typeof(T) == typeof(UnloadAssemblyCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<UnloadAssemblyCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnUnloadAssembly -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnUnloadAssembly -= handler; };
                 instance.OnUnloadAssembly += handler;
             }
             else if (typeof(T) == typeof(ControlCTrapCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<ControlCTrapCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnControlCTrap -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnControlCTrap -= handler; };
                 instance.OnControlCTrap += handler;
             }
             else if (typeof(T) == typeof(NameChangeCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<NameChangeCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnNameChange -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnNameChange -= handler; };
                 instance.OnNameChange += handler;
             }
             else if (typeof(T) == typeof(UpdateModuleSymbolsCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<UpdateModuleSymbolsCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnUpdateModuleSymbols -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnUpdateModuleSymbols -= handler; };
                 instance.OnUpdateModuleSymbols += handler;
             }
             else if (typeof(T) == typeof(EditAndContinueRemapCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<EditAndContinueRemapCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnEditAndContinueRemap -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnEditAndContinueRemap -= handler; };
                 instance.OnEditAndContinueRemap += handler;
             }
             else if (typeof(T) == typeof(BreakpointSetErrorCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<BreakpointSetErrorCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnBreakpointSetError -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnBreakpointSetError -= handler; };
                 instance.OnBreakpointSetError += handler;
             }
             else if (typeof(T) == typeof(FunctionRemapOpportunityCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<FunctionRemapOpportunityCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnFunctionRemapOpportunity -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnFunctionRemapOpportunity -= handler; };
                 instance.OnFunctionRemapOpportunity += handler;
             }
             else if (typeof(T) == typeof(CreateConnectionCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<CreateConnectionCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnCreateConnection -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnCreateConnection -= handler; };
                 instance.OnCreateConnection += handler;
             }
             else if (typeof(T) == typeof(ChangeConnectionCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<ChangeConnectionCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnChangeConnection -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnChangeConnection -= handler; };
                 instance.OnChangeConnection += handler;
             }
             else if (typeof(T) == typeof(DestroyConnectionCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<DestroyConnectionCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnDestroyConnection -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnDestroyConnection -= handler; };
                 instance.OnDestroyConnection += handler;
             }
             else if (typeof(T) == typeof(Exception2CorDebugManagedCallbackEventArgs))
             {
                 EventHandler<Exception2CorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnException2 -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnException2 -= handler; };
                 instance.OnException2 += handler;
             }
             else if (typeof(T) == typeof(ExceptionUnwindCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<ExceptionUnwindCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnExceptionUnwind -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnExceptionUnwind -= handler; };
                 instance.OnExceptionUnwind += handler;
             }
             else if (typeof(T) == typeof(FunctionRemapCompleteCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<FunctionRemapCompleteCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnFunctionRemapComplete -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnFunctionRemapComplete -= handler; };
                 instance.OnFunctionRemapComplete += handler;
             }
             else if (typeof(T) == typeof(MDANotificationCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<MDANotificationCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnMDANotification -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnMDANotification -= handler; };
                 instance.OnMDANotification += handler;
             }
             else if (typeof(T) == typeof(CustomNotificationCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<CustomNotificationCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnCustomNotification -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnCustomNotification -= handler; };
                 instance.OnCustomNotification += handler;
             }
             else if (typeof(T) == typeof(BeforeGarbageCollectionCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<BeforeGarbageCollectionCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnBeforeGarbageCollection -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnBeforeGarbageCollection -= handler; };
                 instance.OnBeforeGarbageCollection += handler;
             }
             else if (typeof(T) == typeof(AfterGarbageCollectionCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<AfterGarbageCollectionCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnAfterGarbageCollection -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnAfterGarbageCollection -= handler; };
                 instance.OnAfterGarbageCollection += handler;
             }
             else if (typeof(T) == typeof(DataBreakpointCorDebugManagedCallbackEventArgs))
             {
                 EventHandler<DataBreakpointCorDebugManagedCallbackEventArgs> handler = null!;
-                handler = (_, e) => { if (Impl((T) (object) e)) instance.OnDataBreakpoint -= handler; };
+                handler = (_, e) => { if (Impl((T)(object)e)) instance.OnDataBreakpoint -= handler; };
                 instance.OnDataBreakpoint += handler;
             }
 

--- a/Data/GameLinks/GameLink.Operation.cs
+++ b/Data/GameLinks/GameLink.Operation.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using ClrDebug;
+﻿using ClrDebug;
 using SpaceEditor.Rocks;
+using System.Runtime.CompilerServices;
 
 namespace SpaceEditor.Data.GameLinks;
 
@@ -16,7 +12,7 @@ public partial class GameLink
         public CorDebugProcess Process { get; init; }
         public CorDebugAppDomain Domain { get; init; }
         public CorDebugAssembly[] Assemblies { get; init; }
-        
+
         public CorDebugManagedCallback Callbacks { get; init; }
 
         public (CorDebugModule Module, mdTypeDef Token) FindType(string typeName)
@@ -49,7 +45,7 @@ public partial class GameLink
                     }
                 }
 
-                Found:
+            Found:
                 if (moduleMd!.TryFindTypeDefByName(typePart, parent, out parent).IsFail())
                 {
                     throw new Exception($"Sub type {typePart} not found in {module!.Name}");
@@ -152,7 +148,7 @@ public partial class GameLink
             var result = await ExecutePreparedEval(eval, expectResult: true);
 
             var handle = result as CorDebugHandleValue;
-            
+
             CorDebugValue value = result;
             if (value is CorDebugReferenceValue ptr)
             {
@@ -175,7 +171,7 @@ public partial class GameLink
                     var toString = FindFunction("System.Object", "ToString");
 
                     eval.CallFunction(toString.Raw, 1, [exception.Raw]);
-                    
+
                     var extractedInfo = await Invoke();
                     if (extractedInfo)
                     {
@@ -208,7 +204,7 @@ public partial class GameLink
                 return null!;
             }
 
-            return (CorDebugHandleValue) eval.Result;
+            return (CorDebugHandleValue)eval.Result;
 
             async Task<bool> Invoke()
             {
@@ -274,7 +270,7 @@ public partial class GameLink
             }
 
             T store = default;
-            genericValue.GetValue((IntPtr) (void*) &store);
+            genericValue.GetValue((IntPtr)(void*)&store);
             return store;
         }
 
@@ -282,8 +278,8 @@ public partial class GameLink
             where T : unmanaged
         {
             var type = PrimitiveRuntimeTypeToCorType(typeof(T));
-            var valueHandle = (CorDebugGenericValue) eval.CreateValue(type, null);
-            valueHandle.SetValue((IntPtr) (void*) &value);
+            var valueHandle = (CorDebugGenericValue)eval.CreateValue(type, null);
+            valueHandle.SetValue((IntPtr)(void*)&value);
             return valueHandle;
         }
 

--- a/Data/GameLinks/GameLink.cs
+++ b/Data/GameLinks/GameLink.cs
@@ -1,8 +1,5 @@
 ﻿using ClrDebug;
-using SpaceEditor.Controls;
-using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace SpaceEditor.Data.GameLinks;
@@ -10,7 +7,7 @@ namespace SpaceEditor.Data.GameLinks;
 public partial class GameLink : IAsyncDisposable
 {
     public GameProxy Game { get; }
-    
+
     private readonly SemaphoreSlim SyncLock = new(1, 1);
     private readonly DbgShim DbgShim;
 
@@ -54,7 +51,7 @@ public partial class GameLink : IAsyncDisposable
         {
             throw new Exception($"Could not find CLR");
         }
-        
+
         //Version String is a comma delimited value containing dbiVersion, pidDebuggee, hmodTargetCLR
         var versionStr = this.DbgShim.CreateVersionStringFromModule(processId, clrs[0].Path);
 
@@ -125,7 +122,7 @@ public partial class GameLink : IAsyncDisposable
             //       Session.Update is large enough to not get inlined, but it's not guaranteed which Scene it will hit on
             // var engineUpdateMethod = op.FindFunction("Keen.VRage.Core.VRageCore", "Update");
             // thread = await op.CatchThreadInFunction(engineUpdateMethod);
-            
+
             var sessionUpdateMethod = op.FindFunction("Keen.VRage.Core.Game.Systems.Session", "Update");
             thread = await op.CatchThreadInFunction(sessionUpdateMethod);
 
@@ -163,17 +160,17 @@ public partial class GameLink : IAsyncDisposable
             // HashSet<Entity>
             var entities = op.ReadField(session, "_activeEntities");
             var entityType = entities.ExactType.FirstTypeParameter;
-            
+
             var toArrayMethod = op.FindFunction("System.Linq.Enumerable", "ToArray");
-            
+
             var eval = thread.CreateEval();
             eval.CallParameterizedFunction(toArrayMethod.Raw, 1, [entityType.Raw], 1, [entities.Raw]);
             var entitiesAsArrayHandle = await op.ExecutePreparedEval(eval, expectResult: true);
             try
             {
-                var entitiesAsArray = (CorDebugArrayValue) entitiesAsArrayHandle.Dereference();
+                var entitiesAsArray = (CorDebugArrayValue)entitiesAsArrayHandle.Dereference();
                 var entitiesCount = entitiesAsArray.Count;
-                
+
                 List<CorDebugHandleValue> componentHandles = new();
                 try
                 {
@@ -181,7 +178,7 @@ public partial class GameLink : IAsyncDisposable
                     {
                         var entity = entitiesAsArray.GetElementAtPosition(i).As<CorDebugReferenceValue>().Dereference();
                         var entityComponentsImmutableArray = op.ReadField(entity, "Components");
-                        var entityComponents = (CorDebugArrayValue) op.ReadField(entityComponentsImmutableArray, "array").As<CorDebugReferenceValue>().Dereference();
+                        var entityComponents = (CorDebugArrayValue)op.ReadField(entityComponentsImmutableArray, "array").As<CorDebugReferenceValue>().Dereference();
 
                         CorDebugValue? componentHit = null;
                         var cc = entityComponents.Count;
@@ -237,11 +234,11 @@ public partial class GameLink : IAsyncDisposable
                 var eval = thread.CreateEval();
                 var colorValue = op.CreatePrimitiveValue(eval, color);
                 eval.CallFunction(fromARGBMethod.Raw, 1, [colorValue.Raw]);
-                
+
                 var colorHandle = await op.ExecutePreparedEval(eval, expectResult: true);
                 try
                 {
-                    foreach(var characterRef in characters)
+                    foreach (var characterRef in characters)
                     {
                         eval.CallFunction(suitColorSetter.Raw, 2, [characterRef.Raw, colorHandle.Raw]);
                         await op.ExecutePreparedEval(eval);

--- a/Data/GameProxy.cs
+++ b/Data/GameProxy.cs
@@ -173,17 +173,28 @@ public class GameProxy
         var inputActionDefinitionType = FindType("InputActionDefinition");
         var actionsDir = GameFacts.GetActionsPath(this.BaseGamePath);
 
-        // Dedicated lock object prevents global thread locking issues
         object syncObj = new object();
 
-        Parallel.ForEach(Directory.EnumerateFiles(actionsDir), file =>
+        // 1. FILTER: Only process actual data files to stop blind SerializationExceptions
+        var validFiles = Directory.EnumerateFiles(actionsDir)
+            .Where(f => f.EndsWith(".sbc", StringComparison.OrdinalIgnoreCase) || f.EndsWith(".json", StringComparison.OrdinalIgnoreCase));
+
+        Parallel.ForEach(validFiles, file =>
         {
             try
             {
+                // 2. FAST PATH: If the file doesn't contain a Guid, it's not an input action. 
+                // Skip it instantly to prevent VRage SerializationExceptions and RuntimeBinderExceptions.
+                string contentPreview = File.ReadAllText(file);
+                if (!contentPreview.Contains("Guid") && !contentPreview.Contains("guid"))
+                    return;
+
                 var def = DeserializeFile(file);
+                if (def == null) return;
+
+                // We know it has a Guid now, so the dynamic binder won't crash
                 Guid id = def.Guid;
 
-                // Safely lock using the dedicated object
                 lock (syncObj)
                 {
                     actions.Actions.Add(id, new InputActions.InputActionInfo
@@ -196,7 +207,9 @@ public class GameProxy
                 }
             }
             catch
-            { }
+            {
+                // Ignore any files that genuinely fail serialization
+            }
         });
 
         var proxy = new ProxyGenerator();
@@ -237,11 +250,24 @@ public class GameProxy
                     if (kind is null)
                         continue;
 
-                    var inputId = DynamicHelper.Unwrap(input.GetValue(null).AsDynamic().Id);
-                    kind.Add(inputId);
+                    try
+                    {
+                        var val = input.GetValue(null);
+                        if (val == null) continue;
 
-                    dynamicProvider.TryGetName(inputId, out string displayName);
-                    inputIds.InputIdToDisplayName.Add(inputId, displayName);
+                        // 3. SAFE REFLECTION: Check if the 'Id' property exists before touching the dynamic binder
+                        var type = val.GetType();
+                        if (type.GetProperty("Id") == null && type.GetField("Id") == null)
+                            continue; // Safely skip without throwing a RuntimeBinderException
+
+                        var inputId = DynamicHelper.Unwrap(val.AsDynamic().Id);
+                        kind.Add(inputId);
+
+                        dynamicProvider.TryGetName(inputId, out string displayName);
+                        inputIds.InputIdToDisplayName.Add(inputId, displayName);
+                    }
+                    catch
+                    { }
                 }
             }
 

--- a/Data/GameProxy.cs
+++ b/Data/GameProxy.cs
@@ -98,6 +98,13 @@ public class GameProxy
     public AsyncLazy<InputIds> InputIds { get; }
     public AsyncLazy<InputActions> InputActions { get; }
 
+    // Pre-cached reflection types to eliminate massive loop bottlenecks
+    private readonly Type _customSerializationContextType;
+    private readonly Type _serializationContextType;
+    private readonly Type _serializationHelperType;
+    private readonly object _jsonFormatEnumValue;
+    private readonly MethodInfo _serializeAbstractMethod;
+
     public GameProxy(string baseGamePath)
     {
         this.BaseGamePath = baseGamePath;
@@ -112,6 +119,13 @@ public class GameProxy
         var md = st.AsDynamicType().GetInstance(mdt);
         md.PushContext(new[] { se2 });
 
+        // CACHE TYPES ONCE AT STARTUP
+        _customSerializationContextType = FindType("CustomSerializationContext");
+        _serializationContextType = FindType("SerializationContext");
+        _serializationHelperType = FindType("SerializationHelper");
+        _jsonFormatEnumValue = Enum.Parse(FindType("SerializerFormat"), "Json");
+        _serializeAbstractMethod = _serializationHelperType.GetMethod("SerializeAbstract")!.MakeGenericMethod(typeof(object));
+
         this.InputIds = new(LoadInputIds);
         this.InputActions = new(LoadInputActions);
     }
@@ -124,31 +138,31 @@ public class GameProxy
 
     public dynamic DeserializeFile(string filePath, params object[] services)
     {
-        using var fs = new FileStream(filePath, FileMode.Open);
+        using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
         return DeserializeObject(fs, services);
     }
 
     public dynamic DeserializeObject(Stream content, params object[] services)
     {
-        var typedServices = Array.CreateInstance(FindType("CustomSerializationContext"), services.Length);
+        // Use pre-cached types instead of FindType() and Enum.Parse()
+        var typedServices = Array.CreateInstance(_customSerializationContextType, services.Length);
         Array.Copy(services, typedServices, services.Length);
 
-        var format = Enum.Parse(FindType("SerializerFormat"), "Json");
-
-        using var sc = (IDisposable)Activator.CreateInstance(FindType("SerializationContext"), content, "NoName.txt", typedServices)!;
-        return FindType("SerializationHelper").AsDynamicType().DeserializeAbstract<object>(sc, format);
+        using var sc = (IDisposable)Activator.CreateInstance(_serializationContextType, content, "NoName.txt", typedServices)!;
+        return _serializationHelperType.AsDynamicType().DeserializeAbstract<object>(sc, _jsonFormatEnumValue);
     }
 
     public string SerializeObject(object instance, params object[] services)
     {
-        var typedServices = Array.CreateInstance(FindType("CustomSerializationContext"), services.Length);
+        // Use pre-cached types
+        var typedServices = Array.CreateInstance(_customSerializationContextType, services.Length);
         Array.Copy(services, typedServices, services.Length);
 
-        var format = Enum.Parse(FindType("SerializerFormat"), "Json");
-
         using var data = new MemoryStream();
-        using var sc = (IDisposable)Activator.CreateInstance(FindType("SerializationContext"), data, "NoName.txt", typedServices)!;
-        FindType("SerializationHelper").GetMethod("SerializeAbstract")!.MakeGenericMethod(typeof(object)).Invoke(null, [sc, instance, format]);
+        using var sc = (IDisposable)Activator.CreateInstance(_serializationContextType, data, "NoName.txt", typedServices)!;
+
+        // Use pre-cached MethodInfo
+        _serializeAbstractMethod.Invoke(null, [sc, instance, _jsonFormatEnumValue]);
 
         return Encoding.UTF8.GetString(data.GetBuffer().AsSpan()[..(int)data.Length]);
     }
@@ -156,18 +170,21 @@ public class GameProxy
     private InputActions LoadInputActions()
     {
         var actions = new InputActions();
-
         var inputActionDefinitionType = FindType("InputActionDefinition");
-
         var actionsDir = GameFacts.GetActionsPath(this.BaseGamePath);
+
+        // Dedicated lock object prevents global thread locking issues
+        object syncObj = new object();
+
         Parallel.ForEach(Directory.EnumerateFiles(actionsDir), file =>
         {
             try
             {
                 var def = DeserializeFile(file);
-
                 Guid id = def.Guid;
-                lock (actionsDir)
+
+                // Safely lock using the dedicated object
+                lock (syncObj)
                 {
                     actions.Actions.Add(id, new InputActions.InputActionInfo
                     {
@@ -181,7 +198,6 @@ public class GameProxy
             catch
             { }
         });
-
 
         var proxy = new ProxyGenerator();
         var mapGuidToDefinitionInstance = proxy.CreateClassProxy

--- a/Data/GameProxy.cs
+++ b/Data/GameProxy.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using Castle.DynamicProxy;
+﻿using Castle.DynamicProxy;
 using ReflectionMagic;
 using SpaceEditor.Rocks;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Text;
 
 namespace SpaceEditor.Data;
 
@@ -33,7 +29,7 @@ public class InputActions
     public InputActionInfo? TryGetInputActionInfo(object inputActionDefinitionStub)
     {
         var id = inputActionDefinitionStub.AsDynamic().Guid;
-        return TryGetInputActionInfo((Guid) id);
+        return TryGetInputActionInfo((Guid)id);
     }
 }
 
@@ -98,7 +94,7 @@ public class GameProxy
     public string BinsPath { get; }
 
     public Assembly MainAssembly { get; }
-    
+
     public AsyncLazy<InputIds> InputIds { get; }
     public AsyncLazy<InputActions> InputActions { get; }
 
@@ -111,10 +107,10 @@ public class GameProxy
         var se2 = ReflectionRocks.GetLib(this.BinsPath, GameFacts.MainDll);
         this.MainAssembly = se2;
 
-        var st =  FindType("Keen.VRage.Library.Utils.Singleton");
+        var st = FindType("Keen.VRage.Library.Utils.Singleton");
         var mdt = FindType("Keen.VRage.Library.Reflection.MetadataManager");
         var md = st.AsDynamicType().GetInstance(mdt);
-        md.PushContext(new[]{se2});
+        md.PushContext(new[] { se2 });
 
         this.InputIds = new(LoadInputIds);
         this.InputActions = new(LoadInputActions);
@@ -139,7 +135,7 @@ public class GameProxy
 
         var format = Enum.Parse(FindType("SerializerFormat"), "Json");
 
-        using var sc = (IDisposable) Activator.CreateInstance(FindType("SerializationContext"), content, "NoName.txt", typedServices)!;
+        using var sc = (IDisposable)Activator.CreateInstance(FindType("SerializationContext"), content, "NoName.txt", typedServices)!;
         return FindType("SerializationHelper").AsDynamicType().DeserializeAbstract<object>(sc, format);
     }
 
@@ -151,7 +147,7 @@ public class GameProxy
         var format = Enum.Parse(FindType("SerializerFormat"), "Json");
 
         using var data = new MemoryStream();
-        using var sc = (IDisposable) Activator.CreateInstance(FindType("SerializationContext"), data, "NoName.txt", typedServices)!;
+        using var sc = (IDisposable)Activator.CreateInstance(FindType("SerializationContext"), data, "NoName.txt", typedServices)!;
         FindType("SerializationHelper").GetMethod("SerializeAbstract")!.MakeGenericMethod(typeof(object)).Invoke(null, [sc, instance, format]);
 
         return Encoding.UTF8.GetString(data.GetBuffer().AsSpan()[..(int)data.Length]);
@@ -257,11 +253,11 @@ public class GameProxy
 
             if (methodName == "TryLocateDefinition" && invocation.Arguments.Length == 3)
             {
-                var id = (Guid) invocation.Arguments[0]!;
-                var type = (Type) invocation.Arguments[1]!;
+                var id = (Guid)invocation.Arguments[0]!;
+                var type = (Type)invocation.Arguments[1]!;
                 invocation.Arguments[2] = this.Actions.TryGetInputActionInfo(id)?.DefinitionInstanceStub ??
                                           DefinitionRocks.AllocateDefinitionStub(type, id);
-                
+
                 invocation.ReturnValue = true;
             }
             else

--- a/Data/GameProxy.cs
+++ b/Data/GameProxy.cs
@@ -119,7 +119,6 @@ public class GameProxy
         var md = st.AsDynamicType().GetInstance(mdt);
         md.PushContext(new[] { se2 });
 
-        // CACHE TYPES ONCE AT STARTUP
         _customSerializationContextType = FindType("CustomSerializationContext");
         _serializationContextType = FindType("SerializationContext");
         _serializationHelperType = FindType("SerializationHelper");
@@ -144,7 +143,6 @@ public class GameProxy
 
     public dynamic DeserializeObject(Stream content, params object[] services)
     {
-        // Use pre-cached types instead of FindType() and Enum.Parse()
         var typedServices = Array.CreateInstance(_customSerializationContextType, services.Length);
         Array.Copy(services, typedServices, services.Length);
 
@@ -154,14 +152,12 @@ public class GameProxy
 
     public string SerializeObject(object instance, params object[] services)
     {
-        // Use pre-cached types
         var typedServices = Array.CreateInstance(_customSerializationContextType, services.Length);
         Array.Copy(services, typedServices, services.Length);
 
         using var data = new MemoryStream();
         using var sc = (IDisposable)Activator.CreateInstance(_serializationContextType, data, "NoName.txt", typedServices)!;
 
-        // Use pre-cached MethodInfo
         _serializeAbstractMethod.Invoke(null, [sc, instance, _jsonFormatEnumValue]);
 
         return Encoding.UTF8.GetString(data.GetBuffer().AsSpan()[..(int)data.Length]);
@@ -176,19 +172,12 @@ public class GameProxy
         object syncObj = new object();
 
         // 1. FILTER: Only process actual data files to stop blind SerializationExceptions
-        var validFiles = Directory.EnumerateFiles(actionsDir)
-            .Where(f => f.EndsWith(".sbc", StringComparison.OrdinalIgnoreCase) || f.EndsWith(".json", StringComparison.OrdinalIgnoreCase));
+        var validFiles = Directory.EnumerateFiles(actionsDir).Where(f => f.EndsWith(".def", StringComparison.OrdinalIgnoreCase) || f.EndsWith(".json", StringComparison.OrdinalIgnoreCase));
 
         Parallel.ForEach(validFiles, file =>
         {
             try
             {
-                // 2. FAST PATH: If the file doesn't contain a Guid, it's not an input action. 
-                // Skip it instantly to prevent VRage SerializationExceptions and RuntimeBinderExceptions.
-                string contentPreview = File.ReadAllText(file);
-                if (!contentPreview.Contains("Guid") && !contentPreview.Contains("guid"))
-                    return;
-
                 var def = DeserializeFile(file);
                 if (def == null) return;
 

--- a/Data/PresetVM.cs
+++ b/Data/PresetVM.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using ReflectionMagic;
+﻿using ReflectionMagic;
 using SpaceEditor.Rocks;
+using System.Collections;
 
 namespace SpaceEditor.Data;
 
@@ -24,7 +20,7 @@ public class PresetVM : VM
     public string DataString { get; private set; }
     public object RootObject { get; private set; }
     public IDictionary Bindings { get; private set; }
-    
+
     public PresetVM(GameProxy game)
     {
         this.Game = game;
@@ -35,11 +31,11 @@ public class PresetVM : VM
         var def = this.Actions.TryGetInputActionInfo(id)?.DefinitionInstanceStub;
         if (def is null)
             return null;
-    
+
         if (this.Bindings.Contains(def) == false)
             return null;
-    
-        return (IList) this.Bindings[def]!;
+
+        return (IList)this.Bindings[def]!;
     }
 
     public void LoadDataString(string content)
@@ -49,9 +45,9 @@ public class PresetVM : VM
 
         this.DataString = content;
         this.RootObject = DynamicHelper.Unwrap(mappings);
-        this.Bindings = (IDictionary) DynamicHelper.Unwrap(mappings.ControlsPerAction);
+        this.Bindings = (IDictionary)DynamicHelper.Unwrap(mappings.ControlsPerAction);
     }
-    
+
     public string ToDataString()
     {
         return this.Game.SerializeObject(this.RootObject);

--- a/Data/Settings.cs
+++ b/Data/Settings.cs
@@ -1,6 +1,6 @@
-﻿using System.Text;
+﻿using SpaceEditor.Rocks;
+using System.Text;
 using System.Windows;
-using SpaceEditor.Rocks;
 
 namespace SpaceEditor.Data;
 
@@ -21,12 +21,12 @@ internal sealed partial class Settings
         // this.SettingsSaving += this.SettingsSavingEventHandler;
         //
     }
-    
+
     private void SettingChangingEventHandler(object sender, System.Configuration.SettingChangingEventArgs e)
     {
         // Add code to handle the SettingChangingEvent event here.
     }
-    
+
     private void SettingsSavingEventHandler(object sender, System.ComponentModel.CancelEventArgs e)
     {
         // Add code to handle the SettingsSaving event here.

--- a/Data/VM.cs
+++ b/Data/VM.cs
@@ -1,19 +1,19 @@
-﻿using System.ComponentModel;
+﻿using SpaceEditor.Rocks;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
-using SpaceEditor.Rocks;
 
 namespace SpaceEditor.Data;
 
 public abstract class VM : INotifyPropertyChanged
 {
     public event PropertyChangedEventHandler? PropertyChanged;
-    
+
     public IDisposable Bind<T>(string property, Action<T> consumer)
     {
         var source = GetType().GetProperty(property)!.GetMethod;
 
         consumer(Getvalue());
-        
+
         PropertyChangedEventHandler handler = (sender, args) =>
         {
             consumer(Getvalue());
@@ -23,13 +23,13 @@ public abstract class VM : INotifyPropertyChanged
         {
             this.PropertyChanged -= handler;
         });
-        
+
         T Getvalue()
         {
-            return (T) source.Invoke(this, null);
+            return (T)source.Invoke(this, null);
         }
     }
-    
+
     protected bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
     {
         if (EqualityComparer<T>.Default.Equals(field, value))

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -10,7 +10,7 @@
         Title="Space Editor"
         Height="550"
         Width="1000"
-        d:DataContext="{local:MainWindow}"
+        d:DataContext="{d:DesignInstance Type=local:MainWindow, IsDesignTimeCreatable=True}"
         >
     <TabControl
         Name="MainTabs"

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -89,11 +89,11 @@ public partial class MainWindow : Window, INotifyPropertyChanged
                 token.ThrowIfCancellationRequested();
 
                 // 2. Pre-warm the Blueprint Generator's heavy static meshes in the background.
-                _ = SpaceEditor.Algorithms.ShapeDB.LargeShapes;
-                _ = SpaceEditor.Algorithms.ShapeDB.MidShapes;
+                _ = Algorithms.GridShaper.ShapeDB.LargeShapes;
+                _ = Algorithms.GridShaper.ShapeDB.MidShapes;
 
                 // 3. Pre-compile the ILGPU Kernel in the background
-                _ = SpaceEditor.Algorithms.GridShaper.GpuSetup.Accelerator;
+                _ = Algorithms.GridShaper.GpuSetup.Accelerator;
 
                 return proxy;
             }, token);

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,5 +1,8 @@
-﻿using System;
-using System.Collections;
+﻿using Microsoft.Win32;
+using SpaceEditor.Controls;
+using SpaceEditor.Data;
+using SpaceEditor.Data.GameLinks;
+using SpaceEditor.Services;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -7,20 +10,18 @@ using System.Text;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Navigation;
-using Microsoft.Win32;
-using SpaceEditor.Controls;
-using SpaceEditor.Data;
-using SpaceEditor.Data.GameLinks;
-using SpaceEditor.Services;
 
 namespace SpaceEditor;
 
 public partial class MainWindow : Window, INotifyPropertyChanged
 {
     public event PropertyChangedEventHandler? PropertyChanged;
-    
+
     private Settings Settings => Settings.Default;
     private GameLink? GameLink;
+
+    // Token to ensure overlapping reloads are safely aborted
+    private CancellationTokenSource? _reloadCts;
 
     public string GamePath
     {
@@ -44,7 +45,7 @@ public partial class MainWindow : Window, INotifyPropertyChanged
             try
             {
                 var latest = await VersionChecker.GetLatestVersionInfo();
-                if (latest.Published.Date != BuildInfo.BuildTimeUtc.Date)
+                if (latest.Published.Date > BuildInfo.BuildTimeUtc.Date)
                 {
                     this.UpdateHints.Visibility = Visibility.Visible;
                 }
@@ -56,6 +57,11 @@ public partial class MainWindow : Window, INotifyPropertyChanged
 
     private async void Reload(object sender, RoutedEventArgs e)
     {
+        // Abort any currently running background initialization
+        _reloadCts?.Cancel();
+        _reloadCts = new CancellationTokenSource();
+        var token = _reloadCts.Token;
+
         var tabs = this.MainTabs.Items;
         while (tabs.Count > 1)
         {
@@ -68,17 +74,36 @@ public partial class MainWindow : Window, INotifyPropertyChanged
             return;
         }
 
-        this.InfoText.Text = "Loading ...";
+        this.InfoText.Text = "Loading Engine and Game Data in background... (This may take a moment)";
+
         try
         {
+            // Offload directory searching and math to the background thread
             var game = await Task.Run(async () =>
             {
-                var game = new GameProxy(this.GamePath);
-                _ = await game.InputActions;
-                _ = await game.InputIds;
-                return game;
-            });
+                // 1. Initialize GameProxy (Searches directory, loads assemblies)
+                var proxy = new GameProxy(this.GamePath);
+                _ = await proxy.InputActions;
+                _ = await proxy.InputIds;
 
+                token.ThrowIfCancellationRequested();
+
+                // 2. Pre-warm the Blueprint Generator's heavy static meshes in the background.
+                _ = SpaceEditor.Algorithms.ShapeDB.LargeShapes;
+                _ = SpaceEditor.Algorithms.ShapeDB.MidShapes;
+
+                // 3. Pre-compile the ILGPU Kernel in the background
+                _ = SpaceEditor.Algorithms.GridShaper.GpuSetup.Accelerator;
+
+                return proxy;
+            }, token);
+
+            // Double check cancellation before touching the main thread engine or UI
+            if (token.IsCancellationRequested) return;
+
+            // 3. Initialize the VRage Engine connection ON THE MAIN THREAD.
+            // Game engines crash (Exit Code 1) if initialized on a background thread.
+            var newGameLink = new GameLink(game);
             var propertyGridFactoryKey = "CompositePropertyGridControlFactory";
             this.Resources.Remove(propertyGridFactoryKey);
             this.Resources.Add(propertyGridFactoryKey, new CompositePropertyGridControlFactory
@@ -110,7 +135,7 @@ public partial class MainWindow : Window, INotifyPropertyChanged
                 await this.GameLink.DisposeAsync();
             }
 
-            this.GameLink = new GameLink(game);
+            this.GameLink = newGameLink;
 
             tabs.Add(new TabItem
             {
@@ -127,7 +152,7 @@ public partial class MainWindow : Window, INotifyPropertyChanged
             var sb = new StringBuilder();
             sb.AppendLine("Loading finished");
             sb.AppendLine();
-            
+
             sb.AppendLine("Main Assembly:");
             var gameExe = game.MainAssembly;
             sb.AppendLine($"{gameExe.GetName().Name}");
@@ -136,8 +161,12 @@ public partial class MainWindow : Window, INotifyPropertyChanged
 
             sb.AppendLine();
             sb.AppendLine("Use Tabs above to access individual features");
-            
+
             this.InfoText.Text = sb.ToString();
+        }
+        catch (OperationCanceledException)
+        {
+            // Silently handle task cancellation if the user changes the path rapidly
         }
         catch (Exception ex)
         {

--- a/Rocks/AsyncLazy.cs
+++ b/Rocks/AsyncLazy.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Runtime.CompilerServices;
 
 namespace SpaceEditor.Rocks;
 

--- a/Rocks/Base6Directions.cs
+++ b/Rocks/Base6Directions.cs
@@ -1,7 +1,4 @@
 ﻿using g4;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace SpaceEditor.Rocks;
 

--- a/Rocks/CollectionRocks.cs
+++ b/Rocks/CollectionRocks.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 namespace SpaceEditor.Rocks;
 
@@ -11,12 +8,12 @@ public static class CollectionRocks
     (
         this Dictionary<TKey, TValue> dictionary,
         TKey key,
-        Func<TKey, TValue>factory
+        Func<TKey, TValue> factory
     )
         where TKey : notnull
     {
         ref var value = ref CollectionsMarshal.GetValueRefOrAddDefault(dictionary, key, out var existed);
-        
+
         if (existed == false)
         {
             value = factory(key);

--- a/Rocks/DefinitionRocks.cs
+++ b/Rocks/DefinitionRocks.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using ReflectionMagic;
+﻿using ReflectionMagic;
 
 namespace SpaceEditor.Rocks;
 

--- a/Rocks/Disposable.cs
+++ b/Rocks/Disposable.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-namespace SpaceEditor.Rocks;
+﻿namespace SpaceEditor.Rocks;
 
 public class Disposable : IDisposable
 {

--- a/Rocks/EnumerableRocks.cs
+++ b/Rocks/EnumerableRocks.cs
@@ -30,7 +30,7 @@ public static class EnumerableRocks
             first = false;
             current = enumerator.Current;
         }
-        
+
         yield return (current, first, Last: true);
     }
 

--- a/Rocks/Enumerators.cs
+++ b/Rocks/Enumerators.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using g4;
+﻿using g4;
 
 namespace SpaceEditor.Rocks;
 
@@ -24,10 +19,10 @@ public static class Enumerators
     public static IEnumerable<Vector3i> BoxRange(Vector3i minInclusive, Vector3i maxInclusive)
     {
         for (int z = minInclusive.z; z <= maxInclusive.z; ++z)
-        for (int y = minInclusive.y; y <= maxInclusive.y; ++y)
-        for (int x = minInclusive.x; x <= maxInclusive.x; ++x)
-        {
-            yield return new(x, y, z);
-        }
+            for (int y = minInclusive.y; y <= maxInclusive.y; ++y)
+                for (int x = minInclusive.x; x <= maxInclusive.x; ++x)
+                {
+                    yield return new(x, y, z);
+                }
     }
 }

--- a/Rocks/MathRocks.cs
+++ b/Rocks/MathRocks.cs
@@ -1,8 +1,4 @@
 ﻿using g4;
-using System;
-using System.Buffers.Text;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace SpaceEditor.Rocks;
 
@@ -41,8 +37,8 @@ public static class MathRocks
     {
         return ForwardUpTranslate
         (
-            (Vector3f) Base6Directions.Vectors[forward],
-            (Vector3f) Base6Directions.Vectors[up],
+            (Vector3f)Base6Directions.Vectors[forward],
+            (Vector3f)Base6Directions.Vectors[up],
             translate
         );
     }
@@ -118,7 +114,7 @@ public static class MathRocks
     {
         return BoxTriangleIntersection.IntersectBoxWithTriangle(box, tri);
     }
-    
+
     public static Bitmap3 Clone(this Bitmap3 value)
     {
         var copy = new Bitmap3(value.Dimensions);

--- a/Rocks/MeshRocks.cs
+++ b/Rocks/MeshRocks.cs
@@ -1,7 +1,4 @@
 ﻿using g4;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace SpaceEditor.Rocks;
 
@@ -9,7 +6,7 @@ public static class MeshRocks
 {
     public static IEnumerable<Triangle3d> EnumerateTriangles(this DMesh3 mesh)
     {
-        foreach(var triangle in mesh.Triangles())
+        foreach (var triangle in mesh.Triangles())
         {
             yield return new
             (
@@ -41,7 +38,7 @@ public static class MeshRocks
         var editor = new MeshEditor(target);
         editor.AppendMesh(source, out var newVertices);
 
-        foreach(var vertexId in newVertices)
+        foreach (var vertexId in newVertices)
         {
             var position = target.GetVertex(vertexId);
             //position = transform.Multiply(ref position);
@@ -126,7 +123,7 @@ public static class MeshRocks
             var vertex = rotation.Multiply(ref vertices[vertexIndex]) * scale + origin;
 
             Vector3d normalD = normal;
-            normal = (Vector3f) rotation.Multiply(ref normalD);
+            normal = (Vector3f)rotation.Multiply(ref normalD);
             indices[i] = mesh.AppendVertex(new NewVertexInfo(vertex, normal));
         }
 

--- a/Rocks/NullToTemplateSelector.cs
+++ b/Rocks/NullToTemplateSelector.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Windows;
 using System.Windows.Controls;
-using System.Windows;
 
 namespace SpaceEditor.Rocks;
 

--- a/Rocks/ReflectionRocks.cs
+++ b/Rocks/ReflectionRocks.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections;
 using System.IO;
 using System.Reflection;
 
@@ -10,9 +8,9 @@ public static class ReflectionRocks
 {
     public static Type? TryFindType(string assemblyHintPath, ReadOnlySpan<string> probeAssemblies, string typeName)
     {
-        foreach(var assembly in probeAssemblies)
+        foreach (var assembly in probeAssemblies)
         {
-            if (GetLib(assemblyHintPath, assembly).TryFindType(typeName) is {} foundType)
+            if (GetLib(assemblyHintPath, assembly).TryFindType(typeName) is { } foundType)
                 return foundType;
         }
 
@@ -59,7 +57,7 @@ public static class ReflectionRocks
     public static Assembly GetLib(string hintPath, string assembly)
     {
         var app = AppDomain.CurrentDomain;
-        if (TryGetPreloadedAssembly(assembly) is {} preloaded)
+        if (TryGetPreloadedAssembly(assembly) is { } preloaded)
         {
             return preloaded;
         }
@@ -67,7 +65,7 @@ public static class ReflectionRocks
         app.AssemblyResolve += (_, args) =>
         {
             var requestedName = new AssemblyName(args.Name).Name;
-            if (TryGetPreloadedAssembly(requestedName) is {} preloaded)
+            if (TryGetPreloadedAssembly(requestedName) is { } preloaded)
             {
                 return preloaded;
             }
@@ -112,7 +110,7 @@ public static class ReflectionRocks
     public static object AllocateObjectBuilder(this Type obType)
     {
         var instance = Activator.CreateInstance(obType)!;
-        
+
         foreach (var field in obType.GetInstanceMembers().OfType<FieldInfo>())
         {
             if (typeof(ICollection).IsAssignableFrom(field.FieldType) == false)

--- a/Rocks/StringCollectionRocks.cs
+++ b/Rocks/StringCollectionRocks.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Specialized;
+﻿using System.Collections.Specialized;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SpaceEditor.Rocks;
 

--- a/Rocks/StringRocks.cs
+++ b/Rocks/StringRocks.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
 using System.Text;
 
 namespace SpaceEditor.Rocks;

--- a/Rocks/ViewRocks.cs
+++ b/Rocks/ViewRocks.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Media;
 
 namespace SpaceEditor.Rocks;
@@ -18,7 +13,7 @@ public static class ViewRocks
             if (current is T found)
                 return found;
 
-            current = (FrameworkElement?) VisualTreeHelper.GetParent(current);
+            current = (FrameworkElement?)VisualTreeHelper.GetParent(current);
 
         }
 

--- a/Services/VersionChecker.cs
+++ b/Services/VersionChecker.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Text.Json;
 
 namespace SpaceEditor.Services;
@@ -21,7 +18,7 @@ public class VersionChecker
         var queryURL = $"https://api.github.com/repos/InflexCZE/SpaceEditor/releases/latest";
 
         var latestReleaseJSON = await DownloadStringAsync(queryURL).ConfigureAwait(false);
-        
+
         var data = JsonDocument.Parse(latestReleaseJSON).RootElement;
         var assets = data.GetProperty("assets").EnumerateArray();
         return new()

--- a/SpaceEditor.csproj
+++ b/SpaceEditor.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Castle.Core" Version="5.2.1" />
     <PackageReference Include="ClrDebug" Version="0.3.4" />
     <PackageReference Include="geometry4Sharp" Version="1.0.0" />
+    <PackageReference Include="ILGPU" Version="1.5.3" />
     <PackageReference Include="Microsoft.Diagnostics.DbgShim" Version="9.0.621003" />
     <PackageReference Include="ObservableCollections" Version="3.3.3" />
     <PackageReference Include="PixiEditor.ColorPicker" Version="3.4.2" />
@@ -50,16 +51,7 @@
 			<BuildInfoFile>$(IntermediateOutputPath)BuildInfo.g.cs</BuildInfoFile>
 		</PropertyGroup>
 
-		<WriteLinesToFile
-			File="$(BuildInfoFile)"
-			Lines=
-			"
-			    internal static class BuildInfo
-			    {
-			        public static DateTime BuildTimeUtc => DateTime.Parse(&quot;$(BuildDateTime)&quot;) %3B
-			    }
-			"
-			Overwrite="true" />
+		<WriteLinesToFile File="$(BuildInfoFile)" Lines="&#xD;&#xA;			    internal static class BuildInfo&#xD;&#xA;			    {&#xD;&#xA;			        public static DateTime BuildTimeUtc =&gt; DateTime.Parse(&quot;$(BuildDateTime)&quot;) %3B&#xD;&#xA;			    }&#xD;&#xA;			" Overwrite="true" />
 
 		<ItemGroup>
 			<Compile Include="$(BuildInfoFile)" />
@@ -71,18 +63,11 @@
 			<ZipOutputPath Include="$(PublishDir)..\..\$(MSBuildProjectName).zip" />
 		</ItemGroup>
 
-		<ZipDirectory
-			SourceDirectory="$(PublishDir).."
-			DestinationFile="@(ZipOutputPath)" />
+		<ZipDirectory SourceDirectory="$(PublishDir).." DestinationFile="@(ZipOutputPath)" />
 
-		<RemoveDir
-            Directories="$(PublishDir)"
-            />
+		<RemoveDir Directories="$(PublishDir)" />
 
-		<Move
-			SourceFiles="@(ZipOutputPath)"
-			DestinationFolder="$(PublishDir)"
-            />
+		<Move SourceFiles="@(ZipOutputPath)" DestinationFolder="$(PublishDir)" />
 
 	</Target>
 


### PR DESCRIPTION
This PR adds a option to generate the blueprint using the graphics card rather than the CPU. Depending on the 3D model used, it could be much faster. Render time is displayed under the model size on the right-side display.
While I was at it, I've enchanced a few things:

- the blueprint generation process is now run on a separate thread, making the program less likey to hang and become irresponsive. A fun side effect is that it is possible to play around with the model displayed on the right side.
- there's now a loading bar that shows the progress of blueprint generation. During the process, it goes over the generation button. Once it's completed it disapears and the button is back.
- the process of loading game files should now be faster, especially visible when debugging. It is also excecuted on a separate thread to prevent hangs
- a general code cleanup, removing unused imports
- the blueprint generation process can now be cancelled by pressing the Esc button, in case the user decided they wanted to try different settings